### PR TITLE
feat: add update and uninstall CLI commands (1.7.0)

### DIFF
--- a/.assets/docs/current-status.md
+++ b/.assets/docs/current-status.md
@@ -2,7 +2,7 @@
 
 This file is the maintainer snapshot for what is live, what is packaged, and what remains open. Keep public positioning in `README.md`; keep operational status here.
 
-## As of 2026-05-27
+## As of 2026-06-01
 
 ### Public surfaces
 
@@ -63,12 +63,14 @@ Working install targets:
 Working CLI surfaces:
 
 - `agentkit-seo version`
+- `agentkit-seo update` (compares the local version against the npm registry latest; explicit, network-only, never automatic; supports `--json` and `--timeout`)
 - `agentkit-seo doctor`
 - `agentkit-seo list providers`
 - `agentkit-seo list skills`
 - `agentkit-seo list commands --provider <provider>`
 - `agentkit-seo template context`
 - `agentkit-seo install --provider <provider>`
+- `agentkit-seo uninstall --provider <provider>` (manifest-driven removal of installed skills, command wrappers, and manifest; supports `--dry-run` and `--force`)
 - `agentkit-seo export --provider <provider|all>`
 
 Every install writes `agentkit-seo-install.json` with package version, provider, skills, commands, and target paths.
@@ -146,7 +148,7 @@ The project is not currently prioritizing:
 - Gemini CLI gallery listing still depends on external crawler/listing behavior after tagged releases.
 - Antigravity CLI command syntax needs live `agy` confirmation.
 - The main source repo still needs a dedicated GitHub social preview.
-- Installed skills include local package metadata but do not compare against npm latest.
+- `agentkit-seo update` provides an explicit npm-latest comparison, but installed skills still carry only local package metadata and do not self-check against npm at agent runtime.
 - Public demo assets and before/after examples are still sparse.
 - Fully automated unattended wiki refresh from live official sources is not shipped; source-tree assisted maintenance is available through the maintainer-only wiki-maintenance skill.
 

--- a/.assets/docs/current-status.md
+++ b/.assets/docs/current-status.md
@@ -9,13 +9,14 @@ This file is the maintainer snapshot for what is live, what is packaged, and wha
 - Source repo: `https://github.com/agentkit-seo/agentkit-seo`
 - Website and human-readable hub: `https://agentkit-seo.github.io/`
 - npm package: `https://www.npmjs.com/package/agentkit-seo`
-- Current package version: `agentkit-seo@1.6.1`
+- Current package version: `agentkit-seo@1.7.0`
 
 Published release line:
 
 - `v0.1.0` through `v0.1.4`
 - `v1.5.0` through `v1.5.3`
 - `v1.6.0` through `v1.6.1`
+- `v1.7.0`
 
 ### Current architecture
 

--- a/.assets/docs/getting-started.md
+++ b/.assets/docs/getting-started.md
@@ -85,6 +85,22 @@ opencode
 shared
 ```
 
+Check whether a newer package is published before reinstalling:
+
+```bash
+npx agentkit-seo update
+```
+
+This compares your local version against the npm registry latest. It runs only when invoked and needs network access; there is no background or automatic check. To update, reinstall from the latest package.
+
+Remove an install with the same provider and destination flags used to install it:
+
+```bash
+npx agentkit-seo uninstall --provider codex
+```
+
+Uninstall reads the install manifest and removes only the AgentKit SEO skill folders, command wrappers, and manifest. Use `--dry-run` to preview removals before deleting anything.
+
 ## 4. First use
 
 Create a private context-file template outside the repository:

--- a/.assets/docs/getting-started.md
+++ b/.assets/docs/getting-started.md
@@ -50,7 +50,7 @@ npx agentkit-seo version
 Expected output:
 
 ```text
-agentkit-seo 1.6.1
+agentkit-seo 1.7.0
 Portable agent skills for LinkedIn, GitHub, CV/ATS, portfolio SEO, X, and agent context optimization.
 ```
 

--- a/.assets/docs/project.md
+++ b/.assets/docs/project.md
@@ -138,7 +138,7 @@ The publish workflow validates the package, checks tag/version alignment, publis
 - Track Gemini gallery listing behavior after release crawler updates.
 - Add a dedicated GitHub social preview for the source repo.
 - Add selective demos or before/after examples when they improve public communication.
-- Consider online latest-version checks for installed agents.
+- The `agentkit-seo update` CLI provides explicit npm-latest checks; consider whether installed agents should surface latest-version status at runtime.
 - Consider more automation around the existing maintainer-only wiki refresh workflow.
 
 ---

--- a/.skills/export/lib/args.mjs
+++ b/.skills/export/lib/args.mjs
@@ -1,12 +1,16 @@
+const BOOLEAN_FLAGS = new Set(["force", "dry-run", "json"]);
+
 export function usage() {
   console.log(`AgentKit SEO CLI
 
 Usage:
   agentkit-seo version
+  agentkit-seo update [--json] [--timeout <ms>]
   agentkit-seo doctor
   agentkit-seo export --provider <provider|all> --output <dir> [--force]
   agentkit-seo install --provider <provider> [--project-root <dir>|--target-dir <dir>] [--commands-target-dir <dir>] [--force]
   agentkit-seo install --provider shared --target-dir <dir> [--force]
+  agentkit-seo uninstall --provider <provider> [--project-root <dir>|--target-dir <dir>] [--dry-run] [--force]
   agentkit-seo template context [--output <file>] [--force]
   agentkit-seo list providers
   agentkit-seo list skills
@@ -23,8 +27,8 @@ export function parseFlags(args) {
       throw new Error(`Unexpected argument: ${token}`);
     }
     const key = token.slice(2);
-    if (key === "force") {
-      flags.force = true;
+    if (BOOLEAN_FLAGS.has(key)) {
+      flags[key] = true;
       continue;
     }
     const value = args[index + 1];

--- a/.skills/export/lib/install.mjs
+++ b/.skills/export/lib/install.mjs
@@ -57,7 +57,7 @@ function writeInstallManifest(
   return manifestPath;
 }
 
-function resolveInstallRoot(flags, providerSpec, provider) {
+export function resolveInstallRoot(flags, providerSpec, provider) {
   if (flags["target-dir"]) {
     return path.resolve(expandUserPath(flags["target-dir"]));
   }
@@ -85,7 +85,7 @@ function resolveInstallRoot(flags, providerSpec, provider) {
   );
 }
 
-function resolveCommandInstallRoot(flags, providerSpec) {
+export function resolveCommandInstallRoot(flags, providerSpec) {
   if (!providerSpec.commandTarget || !providerSpec.commands) {
     return null;
   }
@@ -109,7 +109,7 @@ function resolveCommandInstallRoot(flags, providerSpec) {
   return null;
 }
 
-function resolveAdditionalSkillInstallRoots(flags, providerSpec) {
+export function resolveAdditionalSkillInstallRoots(flags, providerSpec) {
   if (flags["target-dir"]) {
     return [];
   }

--- a/.skills/export/lib/uninstall.mjs
+++ b/.skills/export/lib/uninstall.mjs
@@ -1,0 +1,103 @@
+import fs from "node:fs";
+import path from "node:path";
+
+import { removeIfExists, uniquePaths } from "./filesystem.mjs";
+import {
+  resolveAdditionalSkillInstallRoots,
+  resolveCommandInstallRoot,
+  resolveInstallRoot
+} from "./install.mjs";
+
+const MANIFEST_NAME = "agentkit-seo-install.json";
+
+function readManifest(targetRoot) {
+  const manifestPath = path.join(targetRoot, MANIFEST_NAME);
+  if (!fs.existsSync(manifestPath)) {
+    return null;
+  }
+  try {
+    return JSON.parse(fs.readFileSync(manifestPath, "utf8"));
+  } catch {
+    return null;
+  }
+}
+
+// Collect the exact paths an install created so uninstall removes only AgentKit SEO
+// artifacts. The manifest is authoritative for *where* files landed (it records the
+// resolved skill and command targets); config supplies the skill folder and command
+// file names. When no manifest is present we fall back to recomputing the same paths.
+function collectRemovals(repoRoot, provider, config, flags, manifest, targetRoot) {
+  const providerSpec = config.providers[provider];
+  const layout = manifest?.layout ?? providerSpec.layout;
+
+  // Gemini-style providers install into a dedicated agentkit-seo extension/plugin
+  // directory, so the whole install root is ours to remove.
+  if (layout === "gemini-extension") {
+    return [targetRoot];
+  }
+
+  const removals = [];
+
+  const skillTargets = manifest?.skill_targets ?? uniquePaths([
+    resolveInstallRoot(flags, providerSpec, provider),
+    ...resolveAdditionalSkillInstallRoots(flags, providerSpec)
+  ]);
+  const skillNames =
+    manifest?.skills?.length ? manifest.skills : config.skills.map((skill) => skill.name);
+  for (const skillTarget of skillTargets) {
+    for (const skillName of skillNames) {
+      removals.push(path.join(skillTarget, skillName));
+    }
+  }
+
+  const commandTarget = manifest?.command_target ?? resolveCommandInstallRoot(flags, providerSpec);
+  if (commandTarget && providerSpec.commands) {
+    for (const command of providerSpec.commands) {
+      removals.push(path.join(commandTarget, path.basename(command.source)));
+    }
+  }
+
+  // Remove the manifest itself last so a failed run leaves a record behind.
+  removals.push(path.join(targetRoot, MANIFEST_NAME));
+
+  return removals;
+}
+
+export function uninstallProvider(repoRoot, provider, config, flags) {
+  const providerSpec = config.providers[provider];
+  const targetRoot = resolveInstallRoot(flags, providerSpec, provider);
+  const dryRun = Boolean(flags["dry-run"]);
+  const manifest = readManifest(targetRoot);
+
+  if (!manifest && !flags.force) {
+    throw new Error(
+      `No AgentKit SEO install manifest found at ${targetRoot}. Confirm the install location with --target-dir or --project-root, or pass --force to remove the expected AgentKit SEO files anyway.`
+    );
+  }
+
+  const removals = collectRemovals(repoRoot, provider, config, flags, manifest, targetRoot);
+  const existing = uniquePaths(removals).filter((entry) => fs.existsSync(entry));
+
+  if (existing.length === 0) {
+    console.log(`Nothing to remove for ${provider} at ${targetRoot}.`);
+    return;
+  }
+
+  if (dryRun) {
+    console.log(`Would remove ${existing.length} path(s) for ${provider}:`);
+    for (const entry of existing) {
+      console.log(`- ${entry}`);
+    }
+    return;
+  }
+
+  for (const entry of existing) {
+    removeIfExists(entry);
+  }
+
+  console.log(`Removed ${existing.length} path(s) for ${provider}.`);
+  console.log(`- install root: ${targetRoot}`);
+  for (const entry of existing) {
+    console.log(`- ${entry}`);
+  }
+}

--- a/.skills/export/lib/update.mjs
+++ b/.skills/export/lib/update.mjs
@@ -1,0 +1,134 @@
+import process from "node:process";
+
+const REGISTRY_URL = "https://registry.npmjs.org";
+const DEFAULT_TIMEOUT_MS = 7000;
+
+function parseSemver(version) {
+  const match = /^(\d+)\.(\d+)\.(\d+)(?:[-+]([0-9A-Za-z.-]+))?$/.exec(version ?? "");
+  if (!match) {
+    return null;
+  }
+  return {
+    major: Number(match[1]),
+    minor: Number(match[2]),
+    patch: Number(match[3]),
+    prerelease: match[4] ?? null
+  };
+}
+
+// Returns -1 if a < b, 1 if a > b, 0 if equal, or null if either value is not semver-shaped.
+export function compareSemver(a, b) {
+  const parsedA = parseSemver(a);
+  const parsedB = parseSemver(b);
+  if (!parsedA || !parsedB) {
+    return null;
+  }
+  for (const part of ["major", "minor", "patch"]) {
+    if (parsedA[part] !== parsedB[part]) {
+      return parsedA[part] < parsedB[part] ? -1 : 1;
+    }
+  }
+  if (parsedA.prerelease === parsedB.prerelease) {
+    return 0;
+  }
+  // A normal release outranks any prerelease of the same core version.
+  if (parsedA.prerelease === null) {
+    return 1;
+  }
+  if (parsedB.prerelease === null) {
+    return -1;
+  }
+  return parsedA.prerelease < parsedB.prerelease ? -1 : 1;
+}
+
+async function fetchLatestVersion(name, timeoutMs) {
+  if (typeof fetch !== "function") {
+    throw new Error(
+      "This Node.js runtime has no global fetch(). Upgrade to Node.js 18 or newer to run 'agentkit-seo update'."
+    );
+  }
+
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const response = await fetch(`${REGISTRY_URL}/${encodeURIComponent(name)}/latest`, {
+      headers: { accept: "application/json" },
+      signal: controller.signal
+    });
+    if (!response.ok) {
+      throw new Error(`npm registry returned HTTP ${response.status}.`);
+    }
+    const data = await response.json();
+    if (!data || typeof data.version !== "string") {
+      throw new Error("npm registry response did not include a version.");
+    }
+    return data.version;
+  } catch (error) {
+    if (error?.name === "AbortError") {
+      throw new Error(`npm registry request timed out after ${timeoutMs}ms.`);
+    }
+    throw error;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+export async function checkForUpdates(config, flags) {
+  const name = config.package.name;
+  const current = config.package.version;
+  const asJson = Boolean(flags.json);
+  const timeoutMs = flags.timeout ? Number(flags.timeout) : DEFAULT_TIMEOUT_MS;
+  if (Number.isNaN(timeoutMs) || timeoutMs <= 0) {
+    throw new Error("Invalid --timeout value. Pass a positive number of milliseconds.");
+  }
+
+  let latest;
+  try {
+    latest = await fetchLatestVersion(name, timeoutMs);
+  } catch (error) {
+    if (asJson) {
+      console.log(
+        JSON.stringify({ name, current, latest: null, status: "error", error: error.message }, null, 2)
+      );
+    } else {
+      console.error(`error: could not check npm for the latest ${name} version: ${error.message}`);
+      console.error(
+        "This check needs network access to https://registry.npmjs.org. AgentKit SEO never checks for updates on its own; it only runs when you call 'agentkit-seo update'."
+      );
+    }
+    process.exitCode = 1;
+    return;
+  }
+
+  const comparison = compareSemver(current, latest);
+  let status;
+  if (comparison === null) {
+    status = "unknown";
+  } else if (comparison < 0) {
+    status = "outdated";
+  } else if (comparison > 0) {
+    status = "ahead";
+  } else {
+    status = "current";
+  }
+
+  if (asJson) {
+    console.log(JSON.stringify({ name, current, latest, status }, null, 2));
+    return;
+  }
+
+  console.log(name);
+  console.log(`- installed: ${current}`);
+  console.log(`- npm latest: ${latest}`);
+  if (status === "current") {
+    console.log("You are on the latest published version.");
+  } else if (status === "outdated") {
+    console.log(`An update is available: ${current} -> ${latest}`);
+    console.log("Reinstall the skills from the latest package to update, for example:");
+    console.log("  npx agentkit-seo@latest install --provider <provider> --force");
+  } else if (status === "ahead") {
+    console.log("Your local version is newer than the latest published release.");
+  } else {
+    console.log("Could not compare the versions automatically. Compare the values above manually.");
+  }
+}

--- a/.skills/export/scripts/agentkit-seo.mjs
+++ b/.skills/export/scripts/agentkit-seo.mjs
@@ -11,9 +11,11 @@ import { exportProvider } from "../lib/export.mjs";
 import { installProvider } from "../lib/install.mjs";
 import { listCommands, listProviders, listSkills } from "../lib/list.mjs";
 import { templateContext } from "../lib/template.mjs";
+import { uninstallProvider } from "../lib/uninstall.mjs";
+import { checkForUpdates } from "../lib/update.mjs";
 import { showVersion } from "../lib/version.mjs";
 
-function run() {
+async function run() {
   const [, , command, ...rest] = process.argv;
   if (!command || command === "help" || command === "--help" || command === "-h") {
     usage();
@@ -25,6 +27,12 @@ function run() {
 
   if (command === "version") {
     showVersion(config);
+    return;
+  }
+
+  if (command === "update") {
+    const flags = parseFlags(rest);
+    await checkForUpdates(config, flags);
     return;
   }
 
@@ -83,6 +91,24 @@ function run() {
     return;
   }
 
+  if (command === "uninstall") {
+    const flags = parseFlags(rest);
+    if (!flags.provider) {
+      throw new Error(
+        "Usage: agentkit-seo uninstall --provider <provider> [--project-root <dir>|--target-dir <dir>] [--dry-run] [--force]"
+      );
+    }
+    if (flags.provider === "all") {
+      throw new Error("Uninstall accepts one provider at a time so destinations stay explicit.");
+    }
+    if (!config.providers[flags.provider]) {
+      const available = Object.keys(config.providers).sort().join(", ");
+      throw new Error(`Unknown provider '${flags.provider}'. Available: ${available}`);
+    }
+    uninstallProvider(repoRoot, flags.provider, config, flags);
+    return;
+  }
+
   if (command !== "export") {
     throw new Error(`Unknown command: ${command}`);
   }
@@ -118,9 +144,7 @@ function run() {
   }
 }
 
-try {
-  run();
-} catch (error) {
+run().catch((error) => {
   console.error(`error: ${error.message}`);
   process.exit(1);
-}
+});

--- a/.skills/providers/antigravity/extension/gemini-extension.json
+++ b/.skills/providers/antigravity/extension/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "agentkit-seo",
-  "version": "1.6.1",
+  "version": "1.7.0",
   "description": "Portable personal-branding and discoverability skills for LinkedIn, GitHub, CV/ATS, web portfolios, X, and agent-readable context files.",
   "contextFileName": "GEMINI.md"
 }

--- a/.skills/providers/gemini-cli/extension/gemini-extension.json
+++ b/.skills/providers/gemini-cli/extension/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "agentkit-seo",
-  "version": "1.6.1",
+  "version": "1.7.0",
   "description": "Portable personal-branding and discoverability skills for LinkedIn, GitHub, CV/ATS, web portfolios, X, and agent-readable context files.",
   "contextFileName": "GEMINI.md"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ This project follows npm package versions and mirrors them with matching GitHub 
 
 ## Unreleased
 
+### Added
+
+- Added `agentkit-seo update`, an explicit, opt-in CLI command that compares the local package version against the npm registry latest and reports whether an update is available. It runs only when invoked, supports `--json` and `--timeout`, and never checks for updates automatically.
+- Added `agentkit-seo uninstall --provider <provider>`, which reads the install manifest and removes only the AgentKit SEO skill folders, command wrappers, and manifest it created. Shared skill directories keep unrelated skills; Gemini-style extension and plugin installs remove their dedicated directory. Supports `--dry-run` and `--force`.
+
 ## 1.6.1 - 2026-05-27
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ This project follows npm package versions and mirrors them with matching GitHub 
 
 ## Unreleased
 
+## 1.7.0 - 2026-06-01
+
 ### Added
 
 - Added `agentkit-seo update`, an explicit, opt-in CLI command that compares the local package version against the npm registry latest and reports whether an update is available. It runs only when invoked, supports `--json` and `--timeout`, and never checks for updates automatically.

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -1,6 +1,6 @@
 # Privacy Policy
 
-Last updated: 2026-05-19
+Last updated: 2026-06-01
 
 AgentKit SEO is a local-first, open-source npm package. It provides Markdown skills, provider adapters, command wrappers, templates, and a small CLI for exporting or installing those files into supported agent environments.
 
@@ -56,7 +56,9 @@ AgentKit SEO does not create or upload a personal context file unless the user e
 
 The package CLI is designed to work from local package contents. It does not need a hosted AgentKit SEO service.
 
-Network access may still occur outside the package's control when users:
+The one exception is `agentkit-seo update`: when a user explicitly runs that command, the CLI makes a single outbound request to the public npm registry (`https://registry.npmjs.org`) to read the latest published version of the package. It sends no personal data, runs only when invoked, and is never triggered automatically or in the background. All other CLI commands work from local files only.
+
+Network access may also occur outside the package's control when users:
 
 - install the package from npm or GitHub
 - clone or fetch this repository

--- a/README.md
+++ b/README.md
@@ -201,10 +201,21 @@ Useful package commands:
 
 ```bash
 npx agentkit-seo version
+npx agentkit-seo update
 npx agentkit-seo doctor
 npx agentkit-seo list providers
 npx agentkit-seo list skills
 ```
+
+`update` checks the npm registry for the latest published version and compares it to the version you are running. It only runs when you invoke it; AgentKit SEO never checks for updates on its own. When an update is available, reinstall the skills from the latest package.
+
+Remove an install with the same provider and destination flags used to install it:
+
+```bash
+npx agentkit-seo uninstall --provider codex
+```
+
+`uninstall` reads the `agentkit-seo-install.json` manifest and removes only the AgentKit SEO skill folders, command wrappers, and manifest it created, leaving unrelated skills in shared directories untouched. Use `--dry-run` to preview the removal first.
 
 Install from GitHub without a local clone:
 

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "agentkit-seo",
-  "version": "1.6.1",
+  "version": "1.7.0",
   "description": "Portable personal-branding and discoverability skills for LinkedIn, GitHub, CV/ATS, web portfolios, X, and agent-readable context files.",
   "contextFileName": "GEMINI.md"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agentkit-seo",
-  "version": "1.6.1",
+  "version": "1.7.0",
   "description": "Portable agent skills for LinkedIn, GitHub, CV/ATS, portfolio SEO, X, and agent context optimization.",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary

Adds two opt-in CLI commands to the AgentKit SEO export layer and prepares the `1.7.0` release.

### `agentkit-seo update`
- Compares the local package version against the npm registry latest and reports `current` / `outdated` / `ahead`.
- Runs **only when invoked** — never automatic or in the background.
- Network-guarded: `AbortController` timeout, graceful offline handling. Supports `--json` and `--timeout`.

### `agentkit-seo uninstall --provider <provider>`
- Reads the `agentkit-seo-install.json` manifest and removes **only** the AgentKit SEO skill folders, command wrappers, and manifest it created.
- Shared skill directories (Claude Code, Codex, OpenCode) keep unrelated skills untouched.
- Gemini-style extension/plugin installs remove their dedicated directory.
- Supports `--dry-run` (preview) and `--force` (proceed without a manifest).

### Plumbing
- Exported install's path resolvers for reuse by uninstall.
- Generalized boolean-flag parsing (`force` / `dry-run` / `json`); updated `usage()`; made the CLI entrypoint async.

## Docs
README, getting-started, current-status, project notes, and the changelog updated. PRIVACY.md now discloses that `update` is the CLI's one outbound network call (to npm, no personal data, opt-in only).

## Release
Bumps version to `1.7.0` in `package.json` and all three `gemini-extension.json` manifests; moves the changelog `Unreleased` entries into a `1.7.0` section.

## Validation
- `npm run validate` (doctor) — green
- provider metadata version check (mirrors CI) — OK
- `npm pack --dry-run` — `agentkit-seo-1.7.0.tgz`, 235 files
- Manual smoke tests: install→uninstall for codex / gemini-cli (whole-dir) / opencode (commands); unrelated-skill preservation; no-manifest guard; `update` against the live registry.

https://claude.ai/code/session_01F53sv6ACdNZJ9yjZhj1MVK

---
_Generated by [Claude Code](https://claude.ai/code/session_01F53sv6ACdNZJ9yjZhj1MVK)_