### PR TITLE
docs: add recruiter-facing design overview and concept layer

### DIFF
--- a/.assets/docs/current-status.md
+++ b/.assets/docs/current-status.md
@@ -28,6 +28,7 @@ Published release line:
 - `llms.txt` and `llms-full.txt` expose the LLM-facing map and bundled wiki layer.
 - `.skills/agent-skill/agentkit-seo/wiki/agentkit-seo.md` is the runtime graph entrypoint for installed agents.
 - `.assets/docs/getting-started.md` provides setup onboarding, and `.assets/docs/end-to-end-workflows.md` provides skill-ready demos with prompts, inputs, and expected deliverables.
+- `DESIGN.md` is the human and recruiter-facing design overview: applied agentic-AI concepts mapped to their source and location, a knowledge-graph diagram, and a release-by-release evolution record.
 - Root `skills/`, `commands/`, `GEMINI.md`, and `gemini-extension.json` are generated Gemini-compatible distribution artifacts stored in the repo intentionally.
 
 ### Shipped skill coverage

--- a/.assets/docs/getting-started.md
+++ b/.assets/docs/getting-started.md
@@ -12,6 +12,7 @@ Use this table before opening deeper files.
 | See what a skill-ready agent can do | [end-to-end-workflows.md](./end-to-end-workflows.md) | The matching runtime skill |
 | Build a private career context file | [hub/agent-context-optimization/README.md](../../hub/agent-context-optimization/README.md) | [agent-context skill](../../.skills/agent-skill/agentkit-seo-agent-context-optimization/SKILL.md) |
 | Optimize one public surface | The matching `hub/<module>/README.md` | The matching `.skills/agent-skill/agentkit-seo-<module>/SKILL.md` |
+| Understand the design thinking and concepts applied | [DESIGN.md](../../DESIGN.md) | [architecture-map.md](./architecture-map.md) |
 | Understand the repo architecture | [architecture-map.md](./architecture-map.md) | [.skills/architecture.md](../../.skills/architecture.md) |
 | Understand the runtime knowledge graph | [root runtime wiki](../../.skills/agent-skill/agentkit-seo/wiki/agentkit-seo.md) | [llms.txt](../../llms.txt) |
 | Maintain or release the package | [MAINTAINING.md](../../MAINTAINING.md) | [current-status.md](./current-status.md) |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ This project follows npm package versions and mirrors them with matching GitHub 
 
 ## Unreleased
 
+### Added
+
+- Added `DESIGN.md`, a human and recruiter-facing overview that maps each applied agentic-AI concept (career context file, LLM Wiki, progressive disclosure, Markdown knowledge graph, evidence labeling, one-source-many-adapters) to its origin and to where it lives in the source tree, with a knowledge-graph diagram and a release-by-release record of how the design evolved.
+- Added a `Design principles` section to `README.md` with a concept table and a Mermaid knowledge-graph diagram, plus a `Design` navigation link and a `getting-started.md` path entry.
+
 ### Changed
 
 - Extended `agentkit-seo update --provider <provider>` to read the installed provider manifest and compare that installed skill version against npm latest, so agents can suggest an explicit update check without background network behavior.

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,0 +1,103 @@
+# How AgentKit SEO is built
+
+This document explains the thinking behind AgentKit SEO: the problem it targets, the agentic-AI concepts it deliberately applies, the knowledge-graph structure that holds it together, and how that design has evolved release by release.
+
+It is written for a reader who wants to understand the project quickly, including engineers and recruiters evaluating the work, without reading the whole codebase. For the maintainer-facing edit map, see [architecture-map.md](./.assets/docs/architecture-map.md). For the public overview, see [README.md](./README.md).
+
+## At a glance
+
+- **What it is:** a portable skill bundle that installs into AI coding agents (Claude Code, Codex, Gemini CLI, Antigravity, OpenCode) and helps optimize a developer's public career surfaces: GitHub, LinkedIn, CV/ATS, web portfolio, and X/Twitter.
+- **The problem:** most agents can already rewrite a CV or a bio, but the output drifts between tools, invents facts, and ignores platform constraints. Consistency and grounding are the hard parts.
+- **The core idea:** keep one private, verified source of truth, an agent-context-file, and have every platform skill read it before writing. This is the same pattern as a repository `AGENTS.md` or `CLAUDE.md`, applied to a career.
+- **What makes it interesting:** the project is not a prompt collection. It is a small system that applies current ideas from agentic AI, an LLM-readable knowledge layer, progressive context loading, a cross-referenced knowledge graph, and explicit evidence labeling, and ships them as a validated, versioned package.
+
+## Agentic-AI concepts applied
+
+AgentKit SEO is, in part, a place to apply and pressure-test ideas from the agentic-AI field. Each concept below is implemented in the repository, not just described.
+
+The following table maps each concept to its origin and to where it lives in the source tree.
+
+| Concept | One-line idea | Where it lives |
+| --- | --- | --- |
+| Career context file | A private `AGENTS.md` for a person: verified facts an agent reads before writing | [`agentkit-seo-agent-context-optimization`](./.skills/agent-skill/agentkit-seo-agent-context-optimization/SKILL.md) |
+| LLM Wiki | A knowledge base the model reads, not one it writes | [`*/wiki/`](./.skills/agent-skill/agentkit-seo/wiki/agentkit-seo.md), [`llms-full.txt`](./llms-full.txt) |
+| Progressive disclosure | Load one module, then only the references and wiki a task needs | `## Wiki context` and token-discipline sections in each `SKILL.md` |
+| Markdown knowledge graph | Cross-referenced `.md` files with one entrypoint and explicit edges | [`references/`](./.skills/agent-skill/agentkit-seo/references/) link graph, [`llms.txt`](./llms.txt) |
+| Evidence and confidence labels | Mark each claim as verified, inferred, or needing evidence | `Boundaries` sections and `wiki/` confidence metadata |
+| One source, many adapters | Keep one portable source of truth, generate per-provider layouts | [`.skills/agent-skill/`](./.skills/agent-skill/) plus [`.skills/providers/`](./.skills/providers/) |
+
+### Career context file as an `AGENTS.md` for a person
+
+Developers already accept that a repository should carry a context file so an agent understands the codebase before editing it. AgentKit SEO applies that pattern to a career: a private Markdown file holds verified identity facts, roles, projects, metrics, links, target roles, and positioning. Platform skills read that file first, then adapt the same facts to each surface. This keeps output consistent across LinkedIn, GitHub, CV, and portfolio instead of rebuilding a professional history in every chat.
+
+### LLM Wiki: knowledge the model reads, not writes
+
+The wiki layer follows the LLM Wiki framing associated with Andrej Karpathy: a curated knowledge base that the model consults, rather than one it generates on the fly. Without it, an agent guesses platform constraints, ATS parser behavior, field limits, ranking signals, from training data, and produces confident but wrong advice. Each module ships `wiki/` entries with canonical definitions, platform constraints, known failure modes, and review dates, bundled for tools as [`llms-full.txt`](./llms-full.txt).
+
+### Progressive disclosure and token discipline
+
+Loading every skill into context is wasteful and noisy. Each `SKILL.md` declares, in a `## Wiki context` section, exactly when deeper wiki or reference files should be loaded, so an agent pulls detail only when the current task needs it. The orchestrator routes a request to a single module by default and asks for the smallest missing input set rather than demanding every asset upfront.
+
+### A Markdown knowledge graph
+
+The repository is organized as a navigable graph of Markdown files rather than a flat folder. A single runtime entrypoint, the root wiki, points to module skills, which point to their references and wiki entries, which point to human-readable playbooks and source notes. The edges are explicit relative links, so both humans and agents can traverse from a broad question down to a specific constraint without loading everything. The graph is drawn in the next section.
+
+### Evidence and confidence labeling
+
+Career advice is only useful if its certainty is visible. Cross-surface output labels major claims as verified, from context, from a supplied source, official or current source, inference, needs evidence, or inaccessible. Wiki entries carry confidence values and `last_reviewed` dates, and the `doctor` command validates that metadata. The goal is to separate documented platform behavior from inference instead of presenting everything as fact.
+
+### One portable source, thin provider adapters
+
+Runtime methodology lives once in [`.skills/agent-skill/`](./.skills/agent-skill/). Provider folders stay thin: install notes, command wrappers, and metadata. The export CLI generates each provider's required layout from the single source, so the same methodology installs into six environments without a second copy drifting out of sync.
+
+## The knowledge graph
+
+The intended read path is hierarchical. A broad question enters at the root and narrows to one module and one constraint, instead of loading the whole system.
+
+```mermaid
+flowchart TD
+  CTX["agent-context-file (private source of truth)"]
+  README["README.md"]
+  ROOT["root runtime wiki: agentkit-seo/wiki/agentkit-seo.md"]
+  SKILL["agentkit-seo-(module)/SKILL.md"]
+  REF["references/*.md"]
+  WIDX["wiki/index.md"]
+  WKNOW["wiki/knowledge.md"]
+  HUB["hub/(module)/README.md"]
+  SRC["hub/(module)/sources.md"]
+  LLMS["llms.txt and llms-full.txt"]
+
+  README --> ROOT
+  README --> HUB
+  HUB --> SRC
+  ROOT --> SKILL
+  ROOT --> LLMS
+  SKILL --> REF
+  SKILL --> WIDX
+  WIDX --> WKNOW
+  CTX -. read before writing .-> SKILL
+```
+
+Two properties matter here. First, there is one entrypoint: the root wiki decides which module to load before any module detail is read. Second, the deepest knowledge, module `wiki/knowledge.md`, is only reached when a task actually needs it, which keeps routine work cheap in context.
+
+## How the design evolved
+
+The project is also a record of continuous study: each release line adopted a new idea once it proved useful. The full history is in [CHANGELOG.md](./CHANGELOG.md); the summary below traces the concepts rather than the patches.
+
+- **0.1.x, foundations.** Shipped the package with tag-based npm publishing, a guided context-file template, install manifests, and a `doctor` validation command. The bet here was context-first work plus reproducible packaging.
+- **1.5.x, distribution as adapters.** Hardened multi-provider install and export, added the Gemini-compatible extension layout and the Antigravity plugin layout, and kept one source of truth behind thin adapters.
+- **1.6.x, the knowledge layer.** Added the LLM Wiki layer for every module, the root self-description, conditional wiki loading, shared evidence labels, and `llms.txt` and `llms-full.txt`. This is where the project became a navigable knowledge graph rather than a set of prompts.
+- **1.7.x, operational rigor.** Added a manifest-driven lifecycle to the CLI: `update` compares an installed bundle against the npm registry, and `uninstall` removes exactly what an install created. Reproducibility and clean removal became first-class.
+
+## Sources and influences
+
+These are influences rather than guarantees. AgentKit SEO does not claim ranking outcomes; it applies documented patterns and labels uncertainty.
+
+- The LLM Wiki framing, knowledge the model reads rather than writes, is associated with Andrej Karpathy's commentary on building knowledge for language models.
+- The context-file pattern follows the repository `AGENTS.md` and `CLAUDE.md` convention for giving agents project context before they act.
+- Progressive disclosure follows the agent-skill design idea that an agent should load instructions and reference material only when a task needs them.
+- `llms.txt` and `llms-full.txt` follow an emerging community convention for exposing an AI-readable map of a site or package; this project treats it as a convention, not a search-ranking guarantee.
+
+---
+
+See also: [README.md](./README.md), [architecture-map.md](./.assets/docs/architecture-map.md), [project.md](./.assets/docs/project.md), and [MAINTAINING.md](./MAINTAINING.md).

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@
   <a href="#quick-start">Quick Start</a> •
   <a href="#new-here">New Here?</a> •
   <a href="#modules">Modules</a> •
+  <a href="#design-principles">Design</a> •
   <a href="#install">Install</a> •
   <a href="https://agentkit-seo.github.io/">Website</a> •
   <a href="#authors">Authors</a>
@@ -152,6 +153,45 @@ Keep the context file private. A portable location is:
 ```
 
 This is not a prompt collection. It is an operating manual for agents working on professional identity: verify facts first, then optimize the surface.
+
+## Design principles
+
+AgentKit SEO is a small system that applies current agentic-AI ideas, not just a set of prompts. Each concept below is implemented in the repository.
+
+| Concept | One-line idea | Where it lives |
+| --- | --- | --- |
+| Career context file | A private `AGENTS.md` for a person: verified facts an agent reads before writing | [agent-context-optimization](./.skills/agent-skill/agentkit-seo-agent-context-optimization/SKILL.md) |
+| LLM Wiki | A knowledge base the model reads, not one it writes | [`wiki/`](./.skills/agent-skill/agentkit-seo/wiki/agentkit-seo.md), [llms-full.txt](./llms-full.txt) |
+| Progressive disclosure | Load one module, then only the references a task needs | `## Wiki context` sections in each `SKILL.md` |
+| Markdown knowledge graph | Cross-referenced `.md` files with one entrypoint and explicit edges | [references](./.skills/agent-skill/agentkit-seo/references/), [llms.txt](./llms.txt) |
+| Evidence and confidence labels | Mark each claim as verified, inferred, or needing evidence | `Boundaries` sections and `wiki/` metadata |
+| One source, many adapters | Keep one portable source, generate per-provider layouts | [`.skills/agent-skill/`](./.skills/agent-skill/), [`.skills/providers/`](./.skills/providers/) |
+
+The pieces connect as a navigable graph: a broad question enters at one entrypoint and narrows to a single module and constraint, instead of loading the whole system.
+
+```mermaid
+flowchart TD
+  CTX["agent-context-file (private source of truth)"]
+  README["README.md"]
+  ROOT["root runtime wiki"]
+  SKILL["agentkit-seo-(module)/SKILL.md"]
+  REF["references/*.md"]
+  WIDX["wiki/index.md"]
+  WKNOW["wiki/knowledge.md"]
+  HUB["hub/(module)/README.md"]
+  LLMS["llms.txt and llms-full.txt"]
+
+  README --> ROOT
+  README --> HUB
+  ROOT --> SKILL
+  ROOT --> LLMS
+  SKILL --> REF
+  SKILL --> WIDX
+  WIDX --> WKNOW
+  CTX -. read before writing .-> SKILL
+```
+
+[DESIGN.md](./DESIGN.md) explains each concept, the graph, and how the design evolved release by release.
 
 ## LLM Wiki
 

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "skills",
     "AGENTS.md",
     "CHANGELOG.md",
+    "DESIGN.md",
     "MAINTAINING.md",
     "PRIVACY.md",
     "README.md"


### PR DESCRIPTION
## Summary

Makes the project's scope and applied agentic-AI thinking legible without reading the codebase — aimed at engineers and recruiters evaluating the work. Docs-only; no version bump.

### `DESIGN.md` (new, root)
- **At a glance** 60-second framing (what / problem / core idea / why it's interesting).
- **Agentic-AI concepts applied** — a table mapping each concept to its origin and to where it lives in the source tree, with per-concept rationale: career context file (`AGENTS.md` for a person), LLM Wiki, progressive disclosure, Markdown knowledge graph, evidence/confidence labeling, one-source-many-adapters.
- **The knowledge graph** — a Mermaid diagram of the single-entrypoint → module → constraint read path.
- **How the design evolved** — a release-by-release record (`0.1.x → 1.5.x → 1.6.x → 1.7.x`) tracing concept adoption.
- **Sources and influences** — attributed by name, no fabricated URLs, consistent with the repo's "don't invent claims" rule.

### README
- New `## Design principles` section with the concept table and a Mermaid knowledge-graph diagram (renders natively on GitHub).
- `Design` navigation link.

### Wiring
- `DESIGN.md` ships in the npm package (`package.json` `files`).
- New path-table entry in `getting-started.md`.
- Recorded in `CHANGELOG.md` (`Unreleased`) and `current-status.md`.

## Validation
- `npm run validate` (doctor) — green
- `npm pack --dry-run` — `DESIGN.md` included (9.3kB)
- All relative links resolve: `DESIGN.md` (12) and `README.md` (22)
- Both Mermaid blocks present

## Note
This branch is synced on top of `main` (includes the already-merged `update`/`uninstall` work and the `update --provider` change). The `Unreleased` changelog now holds the design layer plus the `update --provider` change, ready for the next release.

https://claude.ai/code/session_01F53sv6ACdNZJ9yjZhj1MVK

---
_Generated by [Claude Code](https://claude.ai/code/session_01F53sv6ACdNZJ9yjZhj1MVK)_