### PR TITLE
docs: add GitHub and LinkedIn before/after worked examples

### DIFF
--- a/.assets/docs/current-status.md
+++ b/.assets/docs/current-status.md
@@ -151,7 +151,7 @@ The project is not currently prioritizing:
 - Antigravity CLI command syntax needs live `agy` confirmation.
 - The main source repo still needs a dedicated GitHub social preview.
 - Installed skills can prompt an explicit `agentkit-seo update --provider <provider>` check against npm, but they still do not perform background update checks at agent runtime.
-- Public demo assets and before/after examples are still sparse.
+- Worked before/after examples now exist for GitHub and LinkedIn under `hub/*/examples/`; CV/ATS, web-portfolio, and X/Twitter still lack equivalent before/after artifacts.
 - Fully automated unattended wiki refresh from live official sources is not shipped; source-tree assisted maintenance is available through the maintainer-only wiki-maintenance skill.
 
 ---

--- a/.assets/docs/end-to-end-workflows.md
+++ b/.assets/docs/end-to-end-workflows.md
@@ -347,7 +347,16 @@ Expected output:
 - follow-up prompts for each focused skill
 ```
 
-## 9. See also
+## 9. Worked before and after examples
+
+The demos above show prompts and expected output shapes. For concrete before and after artifacts grounded in a public sample context file, see:
+
+- [GitHub profile before and after](../../hub/github/examples/profile-readme-before-after.md)
+- [LinkedIn headline and About before and after](../../hub/linkedin/examples/headline-and-about-before-after.md)
+
+Both reuse the [sample context file](../../hub/agent-context-optimization/examples/renato-mignone-context-file-example.md) so the optimized output stays traceable to verified facts.
+
+## 10. See also
 
 - [Getting started](./getting-started.md)
 - [Architecture map](./architecture-map.md)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This project follows npm package versions and mirrors them with matching GitHub 
 
 - Added `DESIGN.md`, a human and recruiter-facing overview that maps each applied agentic-AI concept (career context file, LLM Wiki, progressive disclosure, Markdown knowledge graph, evidence labeling, one-source-many-adapters) to its origin and to where it lives in the source tree, with a knowledge-graph diagram and a release-by-release record of how the design evolved.
 - Added a `Design principles` section to `README.md` with a concept table and a Mermaid knowledge-graph diagram, plus a `Design` navigation link and a `getting-started.md` path entry.
+- Added worked before/after examples for GitHub and LinkedIn under `hub/github/examples/` and `hub/linkedin/examples/`, grounded in the public sample context file and linked from the module READMEs and the end-to-end demos doc.
 
 ### Changed
 

--- a/hub/github/README.md
+++ b/hub/github/README.md
@@ -74,6 +74,6 @@ When an AI agent is tasked with optimizing a user's GitHub presence:
 
 ---
 
-Runtime skill: [.skills/agent-skill/agentkit-seo-github/SKILL.md](../../.skills/agent-skill/agentkit-seo-github/SKILL.md). Source notes: [sources.md](./sources.md).
+Runtime skill: [.skills/agent-skill/agentkit-seo-github/SKILL.md](../../.skills/agent-skill/agentkit-seo-github/SKILL.md). Source notes: [sources.md](./sources.md). Worked example: [profile before and after](./examples/profile-readme-before-after.md).
 
 *Next step: Understand the search engine in [GitHub code search and Blackbird](./algorithm-blackbird.md).*

--- a/hub/github/examples/profile-readme-before-after.md
+++ b/hub/github/examples/profile-readme-before-after.md
@@ -1,0 +1,103 @@
+# GitHub profile before and after
+
+> Illustrative example built from the public [sample context file](../../agent-context-optimization/examples/renato-mignone-context-file-example.md). It shows the kind of output `agentkit-seo-github` produces from verified facts. It is a worked illustration, not a ranking guarantee, and every "after" line traces back to a fact already present in the context file.
+
+This example optimizes three GitHub surfaces for hiring and search visibility: the profile bio, the profile README, and repository packaging. The rules applied here come from [GitHub section recipes](../../../.skills/agent-skill/agentkit-seo-github/references/section-recipes.md) and [profile-readme.md](../profile-readme.md). The persona is a cybersecurity master's student and security research engineer; the target audience is security and software hiring managers.
+
+## Profile bio
+
+The bio field is limited to 160 characters and should read as `Role | Stack | Location or Remote`.
+
+**Before:**
+
+```text
+CS student. Passionate about tech and security. Always learning new things!
+```
+
+**After:**
+
+```text
+Security Research Engineer | Post-quantum crypto, eBPF, AI for security | MSc Cybersecurity @ PoliTo | Düsseldorf
+```
+
+**Why:** The before line spends the most valuable text in the profile on fluff ("Passionate", "Always learning") that recruiters do not search for. The after line leads with the current role, names three central specialties that double as search keywords, and states location, following the `Role | Stack | Location` recipe. Every claim is verified in the context file.
+
+## Profile README
+
+The README should front-load the strongest keywords, use real Markdown headings, and keep evidence-backed projects above decorative cards.
+
+**Before:**
+
+```text
+# Hi there
+
+Welcome to my GitHub! I'm a passionate developer who loves coding and
+cybersecurity. I enjoy working on cool projects and learning new technologies.
+Feel free to look around!
+
+![stats](https://github-readme-stats.example/api?username=user)
+```
+
+**After:**
+
+```text
+# Renato Mignone
+
+Security research engineer and cybersecurity master's student working on
+post-quantum cryptography, AI for security, and low-level systems security.
+Currently researching quantum-resistant anonymous authentication tokens at
+Huawei Data Privacy Lab.
+
+## Focus areas
+
+- Post-quantum cryptography, zero-knowledge proofs, and OPRFs
+- AI and machine learning for threat detection
+- Linux kernel and eBPF security, network and hardware security
+
+## Featured projects
+
+- Linux eBPF verifier bypass research: 5 confirmed local privilege-escalation
+  vulnerabilities in the Linux 6.8 LTS kernel, with working proofs of concept.
+- AI-driven threat detection: multi-model defence suite reaching 97.5% network-flow
+  and 98.1% malware API-call classification.
+- SoftEther VPN Guardian: dual-protocol enterprise VPN lab (IPsec and TLS) validated
+  with Wireshark packet forensics.
+
+## Contact
+
+- LinkedIn: linkedin.com/in/renato-mignone
+- Portfolio: renatomignone.github.io
+```
+
+**Why:** The before README buries identity behind a generic greeting and lets a stats card stand in for explanation. The after README opens with the name and a keyword-rich summary paragraph, uses real headings, and leads with three projects whose results are stated precisely and are all present in the context file. Security claims keep their exact scope (for example "5 confirmed" vulnerabilities) rather than amplifying impact.
+
+## Repository packaging
+
+For a featured repository, set concrete About text and accurate topics instead of leaving them empty.
+
+**Before:**
+
+```text
+About: personal project
+Topics: (none)
+```
+
+**After:**
+
+```text
+About: ML and NLP pipeline classifying ~230,000 honeypot SSH sessions into MITRE
+ATT&CK attacker-intent categories.
+Topics: machine-learning, nlp, cybersecurity, mitre-attack, bert, honeypot, python
+```
+
+**Why:** "Personal project" tells a recruiter or GitHub search nothing. The after About text front-loads what the project is and the scale of the dataset, and the topics include the core language, the technique, and the domain, which is what the recipe asks for.
+
+## What this example does not claim
+
+- It does not promise a search-ranking position; GitHub search and the feed are not guaranteed by copy alone.
+- It does not invent metrics. Each number is copied from the verified context file.
+- It does not add `AGENTS.md` guidance, because these repositories are showcase projects rather than agent-facing codebases.
+
+---
+
+See also: [profile-readme.md](../profile-readme.md), [repository-seo.md](../repository-seo.md), [section recipes](../../../.skills/agent-skill/agentkit-seo-github/references/section-recipes.md), and the [sample context file](../../agent-context-optimization/examples/renato-mignone-context-file-example.md).

--- a/hub/linkedin/README.md
+++ b/hub/linkedin/README.md
@@ -85,4 +85,4 @@ When an AI agent is tasked with optimizing a user's LinkedIn profile:
 
 ---
 
-Runtime skill: [.skills/agent-skill/agentkit-seo-linkedin/SKILL.md](../../.skills/agent-skill/agentkit-seo-linkedin/SKILL.md). Source notes: [sources.md](./sources.md).
+Runtime skill: [.skills/agent-skill/agentkit-seo-linkedin/SKILL.md](../../.skills/agent-skill/agentkit-seo-linkedin/SKILL.md). Source notes: [sources.md](./sources.md). Worked example: [headline and About before and after](./examples/headline-and-about-before-after.md).

--- a/hub/linkedin/examples/headline-and-about-before-after.md
+++ b/hub/linkedin/examples/headline-and-about-before-after.md
@@ -1,0 +1,72 @@
+# LinkedIn headline and About before and after
+
+> Illustrative example built from the public [sample context file](../../agent-context-optimization/examples/renato-mignone-context-file-example.md). It shows the kind of output `agentkit-seo-linkedin` produces from verified facts. It is a worked illustration, not a ranking guarantee, and every "after" line traces back to a fact already present in the context file.
+
+This example rewrites the two highest-leverage LinkedIn fields, the headline and the About section, for a cybersecurity security research engineer targeting security and research roles. The rules applied here come from [headline-strategy.md](../headline-strategy.md) and [about-section.md](../about-section.md).
+
+## Headline
+
+The headline travels with the name across search, comments, and the feed. The recipe is `[Target Role] | [Top 2-3 stacks] | [Impact or USP]`, with clean delimiters and no buzzwords.
+
+**Before:**
+
+```text
+Passionate Cybersecurity Student | Tech Enthusiast | Always learning
+```
+
+**After:**
+
+```text
+Security Research Engineer | Post-Quantum Cryptography, Rust, AI for Security | Building quantum-resistant authentication at Huawei Data Privacy Lab
+```
+
+**Why:** The before headline uses banned filler ("Passionate", "Tech Enthusiast", "Always learning") that recruiters never search for and that wastes the most visible text on the profile. The after headline follows the Role + Stack + Impact formula, separates blocks with pipes, and ends on a concrete, verified current project. Every element is a fact in the context file.
+
+## About section
+
+The About section should open with a concrete positioning sentence, support it with specific proof, and avoid corporate buzzwords.
+
+**Before:**
+
+```text
+I am a passionate and motivated person who loves technology and cybersecurity.
+I am always looking to learn new things and improve my skills. I enjoy
+working in teams and solving challenging problems. I am open to new
+opportunities in the tech field.
+```
+
+**After:**
+
+```text
+Security research engineer and cybersecurity master's student (Politecnico di
+Torino, GPA 29.48/30) working at the intersection of cryptography, AI, and
+low-level systems security.
+
+I currently research post-quantum anonymous authentication tokens at Huawei Data
+Privacy Lab, implementing NIST PQC candidates and zero-knowledge proof
+constructions in Rust. My recent project work includes:
+
+- Discovering 5 local privilege-escalation vulnerabilities in the Linux 6.8 LTS
+  kernel by bypassing the eBPF static verifier.
+- Building AI threat-detection models reaching 97.5% network-flow and 98.1%
+  malware API-call classification.
+- Winning 1st place at the IEEE-HKN International Budget Hack 2025 as backend and
+  security lead.
+
+I am most interested in roles spanning applied cryptography, AI for security, and
+systems security.
+
+Proof: github.com/RenatoMignone · renatomignone.github.io
+```
+
+**Why:** The before section is entirely generic and contains no verifiable claim a recruiter can act on. The after section front-loads role and specialty, then supports it with precise, verified achievements and proof links. It keeps security claims at their exact scope and avoids the buzzwords the headline rules prohibit.
+
+## What this example does not claim
+
+- It does not promise reach or ranking; the LinkedIn feed and search are not guaranteed by copy alone.
+- It does not invent metrics, titles, or employers. Each claim is copied from the verified context file.
+- It uses the background "Open to Work" setting rather than an "actively seeking" tag in the headline, as the headline anti-pattern guidance recommends.
+
+---
+
+See also: [headline-strategy.md](../headline-strategy.md), [about-section.md](../about-section.md), and the [sample context file](../../agent-context-optimization/examples/renato-mignone-context-file-example.md).


### PR DESCRIPTION
## Summary

Adds concrete before/after worked examples for GitHub and LinkedIn, closing the gap `current-status.md` flagged ("public demo assets and before/after examples are still sparse"). Docs-only; no version bump.

### New examples
- **`hub/github/examples/profile-readme-before-after.md`** — before/after for the profile bio (160-char `Role | Stack | Location`), the profile README, and repository packaging (About text + topics). Each block cites the relevant [GitHub section recipe](https://github.com/agentkit-seo/agentkit-seo/blob/main/.skills/agent-skill/agentkit-seo-github/references/section-recipes.md).
- **`hub/linkedin/examples/headline-and-about-before-after.md`** — before/after for the headline (Role + Stack + Impact formula) and the About section, anchored to the headline and About strategy rules.

### Why they stay credible
- Both reuse the public [sample context file](https://github.com/agentkit-seo/agentkit-seo/blob/main/hub/agent-context-optimization/examples/renato-mignone-context-file-example.md), so every "after" line traces to a verified fact — no invented metrics.
- Each ends with a "what this example does not claim" note (no ranking promises, exact-scope security claims, `AGENTS.md` only where warranted), matching the project's anti-overclaim posture.

### Wiring
- Linked from the GitHub and LinkedIn hub READMEs and from a new section in `end-to-end-workflows.md`.
- Recorded in `CHANGELOG.md` (`Unreleased`) and softened the corresponding open gap in `current-status.md`.
- Ships in the npm package automatically (the `hub/` tree is already in `files`).

## Validation
- `npm run validate` (doctor) — green
- All 13 relative links in the new files resolve
- No emoji (STYLEGUIDE compliance)
- `npm pack --dry-run` — both example files included

## Note
`Unreleased` now holds: the `update --provider` enhancement, the design layer (merged in #2), and these before/after examples — ready to roll into the next release (e.g. 1.8.0) whenever you want to cut it.

https://claude.ai/code/session_01F53sv6ACdNZJ9yjZhj1MVK

---
_Generated by [Claude Code](https://claude.ai/code/session_01F53sv6ACdNZJ9yjZhj1MVK)_