### PR TITLE
test + docs: CLI unit tests, skill-description lint, GEO/AEO and legibility

### DIFF
--- a/.assets/docs/STYLEGUIDE.md
+++ b/.assets/docs/STYLEGUIDE.md
@@ -216,7 +216,7 @@ When generating or editing Markdown:
 - Match the correct file-class schema.
 - Set complete hidden metadata for editorial hub files.
 - Set `status: draft` for new editorial files unless told otherwise.
-- Use Agent Skills frontmatter for runtime `SKILL.md` files.
+- Use Agent Skills frontmatter for runtime `SKILL.md` files. The `description` must state both what the skill does and when to use it: write one or two sentences of capability, then a "Use when ..." clause listing concrete triggers. Keep it within 1024 characters and push detail into `references/`. `agentkit-seo doctor` enforces the presence, length, and "when" clause.
 - Keep runtime references lean, procedural, and self-contained.
 - Use the current date for `last_updated`.
 - Do not add sections outside the relevant template.

--- a/.assets/docs/current-status.md
+++ b/.assets/docs/current-status.md
@@ -85,7 +85,7 @@ The runtime wiki layer is installed and exported with provider bundles.
 - `llms-full.txt` concatenates the root wiki, module wiki indexes, and module knowledge files.
 - The root runtime wiki explains the graph navigation contract before agents load module details.
 - Module `SKILL.md` files use `## Wiki context` to declare when wiki files should be loaded.
-- `agentkit-seo doctor` validates wiki metadata, review dates, links, module/folder matches, skill wiki-context sections, Gemini mirror coverage, and package `files` inclusion for LLM-facing files.
+- `agentkit-seo doctor` validates wiki metadata, review dates, links, module/folder matches, skill wiki-context sections, skill description convention (what plus when, within 1024 characters), Gemini mirror coverage, and package `files` inclusion for LLM-facing files.
 - `agentkit-seo-wiki-maintenance` exists in the source tree as a maintainer-only local audit workflow; it is not part of the seven installed runtime skills.
 
 ### Website and discovery status
@@ -121,6 +121,7 @@ Website automation:
 
 Validation surfaces currently include:
 
+- `npm test` (deterministic `node:test` unit suite for the CLI library)
 - `npm run validate`
 - CLI version check
 - provider export smoke test

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -24,6 +24,9 @@ jobs:
         with:
           node-version: "22"
 
+      - name: Run unit tests
+        run: npm test
+
       - name: Validate CLI package layout
         run: npm run validate
 

--- a/.skills/export/lib/doctor.mjs
+++ b/.skills/export/lib/doctor.mjs
@@ -349,6 +349,45 @@ function validateGeminiMarketplaceLayout(repoRoot, config, packageMetadata, erro
   validateGeminiWikiMirror(repoRoot, config, errors);
 }
 
+function readSkillFrontmatter(skillFilePath) {
+  const content = fs.readFileSync(skillFilePath, "utf8");
+  const match = content.match(/^---\n([\s\S]*?)\n---/);
+  return match ? match[1] : null;
+}
+
+// Enforce the Agent Skills description convention: every skill states what it does
+// AND when to use it, within the 1024-character description budget. Agents tend to
+// under-trigger skills whose descriptions omit the "when", so this is a hard check.
+function validateSkillDescriptions(repoRoot, config, errors) {
+  for (const skill of config.skills ?? []) {
+    const skillFile = path.join(repoRoot, skill.source, "SKILL.md");
+    if (!fs.existsSync(skillFile)) {
+      continue;
+    }
+    const frontmatter = readSkillFrontmatter(skillFile);
+    if (!frontmatter) {
+      errors.push(`${skill.source}/SKILL.md is missing YAML frontmatter`);
+      continue;
+    }
+    const descMatch = frontmatter.match(/^description:\s*(.+)$/m);
+    const description = descMatch ? descMatch[1].trim().replace(/^["']|["']$/g, "") : "";
+    if (!description) {
+      errors.push(`${skill.source}/SKILL.md frontmatter is missing description`);
+      continue;
+    }
+    if (description.length > 1024) {
+      errors.push(
+        `${skill.source}/SKILL.md description is ${description.length} chars; keep it within 1024 and move detail into references/`
+      );
+    }
+    if (!/\buse\b[\s\S]*\bwhen\b/i.test(description)) {
+      errors.push(
+        `${skill.source}/SKILL.md description must state when to use the skill (include a "Use when ..." clause)`
+      );
+    }
+  }
+}
+
 export function doctor(repoRoot, config) {
   const errors = [];
   const warnings = [];
@@ -434,6 +473,7 @@ export function doctor(repoRoot, config) {
   for (const [provider, providerSpec] of Object.entries(config.providers ?? {})) {
     validateProvider(repoRoot, provider, providerSpec, packageMetadata, errors);
   }
+  validateSkillDescriptions(repoRoot, config, errors);
   validateWikiFiles(repoRoot, config, errors, warnings);
   validateGeminiMarketplaceLayout(repoRoot, config, packageMetadata, errors);
 
@@ -450,6 +490,7 @@ export function doctor(repoRoot, config) {
 
   console.log(`ok: package ${packageMetadata.name}@${packageMetadata.version}`);
   console.log(`ok: ${config.skills.length} skill source(s)`);
+  console.log("ok: skill descriptions state what and when");
   console.log(`ok: ${Object.keys(config.providers).length} provider adapter(s)`);
   console.log("ok: context template available");
   console.log("ok: wiki files valid");

--- a/.skills/export/lib/uninstall.mjs
+++ b/.skills/export/lib/uninstall.mjs
@@ -26,7 +26,7 @@ function readManifest(targetRoot) {
 // artifacts. The manifest is authoritative for *where* files landed (it records the
 // resolved skill and command targets); config supplies the skill folder and command
 // file names. When no manifest is present we fall back to recomputing the same paths.
-function collectRemovals(repoRoot, provider, config, flags, manifest, targetRoot) {
+export function collectRemovals(repoRoot, provider, config, flags, manifest, targetRoot) {
   const providerSpec = config.providers[provider];
   const layout = manifest?.layout ?? providerSpec.layout;
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,14 @@ This project follows npm package versions and mirrors them with matching GitHub 
 
 - Added `DESIGN.md`, a human and recruiter-facing overview that maps each applied agentic-AI concept (career context file, LLM Wiki, progressive disclosure, Markdown knowledge graph, evidence labeling, one-source-many-adapters) to its origin and to where it lives in the source tree, with a knowledge-graph diagram and a release-by-release record of how the design evolved.
 - Added a `Design principles` section to `README.md` with a concept table and a Mermaid knowledge-graph diagram, plus a `Design` navigation link and a `getting-started.md` path entry.
+- Added a `node:test` unit suite under `test/` covering semver comparison, CLI flag parsing, package-file matching, install-root resolution, and uninstall path collection, wired into CI through an `npm test` step in `validate.yml`.
+- Named AI-answer-engine readiness (GEO/AEO) as an applied concept in `README.md` and `DESIGN.md`, mapped to the existing per-module AI-readability guidance and labeled as an evolving practice with no ranking guarantee.
+- Added a one-source-to-many-adapters distribution diagram to the `README.md` repository layout section.
 
 ### Changed
 
 - Extended `agentkit-seo update --provider <provider>` to read the installed provider manifest and compare that installed skill version against npm latest, so agents can suggest an explicit update check without background network behavior.
+- Extended `agentkit-seo doctor` to enforce the Agent Skills description convention: every configured skill must declare a non-empty `description` within 1024 characters that states when to use the skill. Documented the convention in `STYLEGUIDE.md`.
 
 ## 1.7.0 - 2026-06-01
 

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -25,6 +25,7 @@ The following table maps each concept to its origin and to where it lives in the
 | Markdown knowledge graph | Cross-referenced `.md` files with one entrypoint and explicit edges | [`references/`](./.skills/agent-skill/agentkit-seo/references/) link graph, [`llms.txt`](./llms.txt) |
 | Evidence and confidence labels | Mark each claim as verified, inferred, or needing evidence | `Boundaries` sections and `wiki/` confidence metadata |
 | One source, many adapters | Keep one portable source of truth, generate per-provider layouts | [`.skills/agent-skill/`](./.skills/agent-skill/) plus [`.skills/providers/`](./.skills/providers/) |
+| AI-answer-engine readiness (GEO/AEO) | Structure each surface so AI search and assistants can quote a person accurately | per-module AI-readability guidance ([GitHub](./hub/github/copilot-and-agents.md), [LinkedIn](./hub/linkedin/ai-agent-optimization.md), [portfolio](./hub/web-portfolio/llms-and-aeo.md)) |
 
 ### Career context file as an `AGENTS.md` for a person
 
@@ -49,6 +50,10 @@ Career advice is only useful if its certainty is visible. Cross-surface output l
 ### One portable source, thin provider adapters
 
 Runtime methodology lives once in [`.skills/agent-skill/`](./.skills/agent-skill/). Provider folders stay thin: install notes, command wrappers, and metadata. The export CLI generates each provider's required layout from the single source, so the same methodology installs into six environments without a second copy drifting out of sync.
+
+### AI-answer-engine readiness (GEO/AEO)
+
+Career discovery increasingly happens inside AI answer engines: people and recruiters ask an assistant rather than scanning a list of links. Generative engine optimization and answer engine optimization are the current names for being quoted accurately in those answers. AgentKit SEO does not chase a ranking trick for this; the same properties it already enforces, consistent facts across surfaces, explicit structure, and verifiable proof, are exactly what an answer engine needs to cite a person without inventing or contradicting details. Each platform module already carries surface-specific AI-readability guidance, from GitHub Copilot indexing to LinkedIn AI-readable structure to portfolio AEO. The project treats this as an evolving practice and labels it as such, rather than promising placement in any AI answer.
 
 ## The knowledge graph
 
@@ -96,7 +101,7 @@ These are influences rather than guarantees. AgentKit SEO does not claim ranking
 - The LLM Wiki framing, knowledge the model reads rather than writes, is associated with Andrej Karpathy's commentary on building knowledge for language models.
 - The context-file pattern follows the repository `AGENTS.md` and `CLAUDE.md` convention for giving agents project context before they act.
 - Progressive disclosure follows the agent-skill design idea that an agent should load instructions and reference material only when a task needs them.
-- `llms.txt` and `llms-full.txt` follow an emerging community convention for exposing an AI-readable map of a site or package; this project treats it as a convention, not a search-ranking guarantee.
+- `llms.txt` and `llms-full.txt` follow an emerging community convention for exposing an AI-readable map of a site or package. As of 2026 its adoption is still limited and its measured effect on AI citations is unproven, so this project ships it as a low-cost, honestly-labeled convention (an inferred, low-confidence signal) rather than a search-ranking lever.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -166,6 +166,9 @@ AgentKit SEO is a small system that applies current agentic-AI ideas, not just a
 | Markdown knowledge graph | Cross-referenced `.md` files with one entrypoint and explicit edges | [references](./.skills/agent-skill/agentkit-seo/references/), [llms.txt](./llms.txt) |
 | Evidence and confidence labels | Mark each claim as verified, inferred, or needing evidence | `Boundaries` sections and `wiki/` metadata |
 | One source, many adapters | Keep one portable source, generate per-provider layouts | [`.skills/agent-skill/`](./.skills/agent-skill/), [`.skills/providers/`](./.skills/providers/) |
+| AI-answer-engine readiness (GEO/AEO) | Structure each surface so AI search and assistants can quote a person accurately | [GitHub Copilot indexing](./hub/github/copilot-and-agents.md), [LinkedIn AI structure](./hub/linkedin/ai-agent-optimization.md), [portfolio AEO](./hub/web-portfolio/llms-and-aeo.md) |
+
+Hiring discovery increasingly runs through AI answer engines, so the same properties these modules enforce, consistent facts across surfaces and verifiable proof, are what those systems can quote accurately. The project treats generative and answer engine optimization as an evolving practice with no guaranteed ranking outcome, not a promise.
 
 The pieces connect as a navigable graph: a broad question enters at one entrypoint and narrows to a single module and constraint, instead of loading the whole system.
 
@@ -211,6 +214,22 @@ The repository separates human documentation from runtime agent artifacts:
 - `.skills/export/` contains the install, export, doctor, and template CLI.
 - `.skills/providers/` contains provider-specific adapter notes and wrappers.
 - `commands/`, `skills/`, `GEMINI.md`, and `gemini-extension.json` provide the Gemini-compatible root distribution layout.
+
+One canonical source generates every provider layout, so methodology never drifts between tools:
+
+```mermaid
+flowchart LR
+  SRC[".skills/agent-skill/<br/>canonical SKILL.md + references + wiki"]
+  ADP[".skills/providers/<br/>thin adapters"]
+  EXP[".skills/export/<br/>export + install CLI"]
+  SRC --> EXP
+  ADP --> EXP
+  EXP --> CC["Claude Code"]
+  EXP --> CX["Codex"]
+  EXP --> GM["Gemini CLI / Antigravity"]
+  EXP --> OC["OpenCode"]
+  EXP --> NPM["npm package +<br/>root Gemini mirror"]
+```
 
 Maintainer entrypoints:
 

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "install:skills": "node .skills/export/scripts/agentkit-seo.mjs install",
     "list:providers": "node .skills/export/scripts/agentkit-seo.mjs list providers",
     "list:skills": "node .skills/export/scripts/agentkit-seo.mjs list skills",
+    "test": "node --test",
     "validate": "node .skills/export/scripts/agentkit-seo.mjs doctor",
     "version:cli": "node .skills/export/scripts/agentkit-seo.mjs version"
   },

--- a/test/args.test.mjs
+++ b/test/args.test.mjs
@@ -1,0 +1,27 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { parseFlags } from "../.skills/export/lib/args.mjs";
+
+test("parseFlags reads value flags", () => {
+  const flags = parseFlags(["--provider", "claude-code", "--target-dir", "/tmp/x"]);
+  assert.deepEqual(flags, { provider: "claude-code", "target-dir": "/tmp/x" });
+});
+
+test("parseFlags treats known boolean flags as true", () => {
+  const flags = parseFlags(["--provider", "codex", "--force", "--dry-run", "--json"]);
+  assert.deepEqual(flags, { provider: "codex", force: true, "dry-run": true, json: true });
+});
+
+test("parseFlags throws on a value flag with no value", () => {
+  assert.throws(() => parseFlags(["--provider"]), /Missing value for flag: --provider/);
+  assert.throws(() => parseFlags(["--provider", "--force"]), /Missing value for flag: --provider/);
+});
+
+test("parseFlags throws on a non-flag positional argument", () => {
+  assert.throws(() => parseFlags(["provider"]), /Unexpected argument: provider/);
+});
+
+test("parseFlags returns an empty object for no arguments", () => {
+  assert.deepEqual(parseFlags([]), {});
+});

--- a/test/filesystem.test.mjs
+++ b/test/filesystem.test.mjs
@@ -1,0 +1,58 @@
+import assert from "node:assert/strict";
+import os from "node:os";
+import path from "node:path";
+import { test } from "node:test";
+
+import {
+  expandUserPath,
+  normalizeRelativePath,
+  packageFileIncludes,
+  semverish,
+  trimTrailingSlash,
+  uniquePaths
+} from "../.skills/export/lib/filesystem.mjs";
+
+test("semverish accepts release and prerelease versions", () => {
+  assert.equal(semverish("1.0.0"), true);
+  assert.equal(semverish("1.7.0"), true);
+  assert.equal(semverish("1.0.0-beta.1"), true);
+  assert.equal(semverish("1.0.0+build.5"), true);
+});
+
+test("semverish rejects malformed versions", () => {
+  assert.equal(semverish("1.0"), false);
+  assert.equal(semverish("v1.0.0"), false);
+  assert.equal(semverish("1.0.0.0"), false);
+  assert.equal(semverish("latest"), false);
+  assert.equal(semverish(""), false);
+});
+
+test("trimTrailingSlash normalizes separators and trailing slashes", () => {
+  assert.equal(trimTrailingSlash("hub/github/"), "hub/github");
+  assert.equal(trimTrailingSlash("hub/github///"), "hub/github");
+  assert.equal(trimTrailingSlash("hub/github"), "hub/github");
+});
+
+test("normalizeRelativePath converts OS separators to forward slashes", () => {
+  const native = ["hub", "github", "README.md"].join(path.sep);
+  assert.equal(normalizeRelativePath(native), "hub/github/README.md");
+});
+
+test("expandUserPath resolves the home directory", () => {
+  assert.equal(expandUserPath("~"), os.homedir());
+  assert.equal(expandUserPath("~/.claude/skills"), path.join(os.homedir(), ".claude/skills"));
+  assert.equal(expandUserPath("/tmp/x"), "/tmp/x");
+});
+
+test("uniquePaths dedupes resolved paths and drops empties", () => {
+  const result = uniquePaths(["/tmp/a", "/tmp/a", "", null, "/tmp/b"]);
+  assert.deepEqual(result, [path.resolve("/tmp/a"), path.resolve("/tmp/b")]);
+});
+
+test("packageFileIncludes matches exact entries and parent directories", () => {
+  const files = [".skills/export", "hub", "README.md"];
+  assert.equal(packageFileIncludes(files, "README.md"), true);
+  assert.equal(packageFileIncludes(files, ".skills/export/lib/doctor.mjs"), true);
+  assert.equal(packageFileIncludes(files, "hub/github/README.md"), true);
+  assert.equal(packageFileIncludes(files, ".skills/agent-skill"), false);
+});

--- a/test/install.test.mjs
+++ b/test/install.test.mjs
@@ -1,0 +1,35 @@
+import assert from "node:assert/strict";
+import os from "node:os";
+import path from "node:path";
+import { test } from "node:test";
+
+import { resolveInstallRoot } from "../.skills/export/lib/install.mjs";
+
+test("resolveInstallRoot lets an explicit --target-dir win", () => {
+  const root = resolveInstallRoot({ "target-dir": "/tmp/x" }, { target: ".claude/skills" }, "claude-code");
+  assert.equal(root, path.resolve("/tmp/x"));
+});
+
+test("resolveInstallRoot joins --project-root with the provider target", () => {
+  const root = resolveInstallRoot({ "project-root": "/proj" }, { target: ".claude/skills" }, "claude-code");
+  assert.equal(root, path.resolve("/proj", ".claude/skills"));
+});
+
+test("resolveInstallRoot falls back to the provider globalTarget", () => {
+  const root = resolveInstallRoot({}, { globalTarget: "~/.claude/skills" }, "claude-code");
+  assert.equal(root, path.resolve(os.homedir(), ".claude/skills"));
+});
+
+test("resolveInstallRoot requires a destination for shared installs", () => {
+  assert.throws(
+    () => resolveInstallRoot({}, { layout: "shared", target: "skills" }, "shared"),
+    /Shared installs require --target-dir/
+  );
+});
+
+test("resolveInstallRoot throws when no default target is configured", () => {
+  assert.throws(
+    () => resolveInstallRoot({}, { target: ".x/skills" }, "mystery"),
+    /no default target is configured/
+  );
+});

--- a/test/uninstall.test.mjs
+++ b/test/uninstall.test.mjs
@@ -1,0 +1,74 @@
+import assert from "node:assert/strict";
+import path from "node:path";
+import { test } from "node:test";
+
+import { collectRemovals } from "../.skills/export/lib/uninstall.mjs";
+
+const config = {
+  skills: [{ name: "agentkit-seo" }, { name: "agentkit-seo-github" }],
+  providers: {
+    codex: { layout: "skill-folders" },
+    "gemini-cli": {
+      layout: "gemini-extension",
+      commands: [{ name: "agentkit-seo:context", source: "a/b/context.toml" }]
+    },
+    opencode: {
+      layout: "skill-folders",
+      commands: [{ name: "agentkit-seo:github", source: "x/y/github.md" }]
+    }
+  }
+};
+
+test("gemini-extension layout removes only the dedicated install root", () => {
+  const removals = collectRemovals(
+    "/repo",
+    "gemini-cli",
+    config,
+    {},
+    { layout: "gemini-extension" },
+    "/home/u/.gemini/extensions/agentkit-seo"
+  );
+  assert.deepEqual(removals, ["/home/u/.gemini/extensions/agentkit-seo"]);
+});
+
+test("skill-folders layout removes each skill folder and the manifest, leaving the shared dir", () => {
+  const manifest = {
+    layout: "skill-folders",
+    skill_targets: ["/home/u/.codex/skills"],
+    skills: ["agentkit-seo", "agentkit-seo-github"]
+  };
+  const removals = collectRemovals("/repo", "codex", config, {}, manifest, "/home/u/.codex/skills");
+  assert.deepEqual(removals, [
+    path.join("/home/u/.codex/skills", "agentkit-seo"),
+    path.join("/home/u/.codex/skills", "agentkit-seo-github"),
+    path.join("/home/u/.codex/skills", "agentkit-seo-install.json")
+  ]);
+});
+
+test("skill-folders layout also removes command wrappers when the provider has commands", () => {
+  const manifest = {
+    layout: "skill-folders",
+    skill_targets: ["/t/skills"],
+    skills: ["agentkit-seo"],
+    command_target: "/t/commands"
+  };
+  const removals = collectRemovals("/repo", "opencode", config, {}, manifest, "/t/skills");
+  assert.deepEqual(removals, [
+    path.join("/t/skills", "agentkit-seo"),
+    path.join("/t/commands", "github.md"),
+    path.join("/t/skills", "agentkit-seo-install.json")
+  ]);
+});
+
+test("manifest skill list overrides the configured skills", () => {
+  const manifest = {
+    layout: "skill-folders",
+    skill_targets: ["/t/skills"],
+    skills: ["agentkit-seo-github"]
+  };
+  const removals = collectRemovals("/repo", "codex", config, {}, manifest, "/t/skills");
+  assert.deepEqual(removals, [
+    path.join("/t/skills", "agentkit-seo-github"),
+    path.join("/t/skills", "agentkit-seo-install.json")
+  ]);
+});

--- a/test/update.test.mjs
+++ b/test/update.test.mjs
@@ -1,0 +1,27 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { compareSemver } from "../.skills/export/lib/update.mjs";
+
+test("compareSemver orders core versions", () => {
+  assert.equal(compareSemver("1.0.0", "1.0.1"), -1);
+  assert.equal(compareSemver("1.2.0", "1.1.9"), 1);
+  assert.equal(compareSemver("2.0.0", "1.9.9"), 1);
+  assert.equal(compareSemver("1.7.0", "1.7.0"), 0);
+});
+
+test("compareSemver treats a release as newer than its prerelease", () => {
+  assert.equal(compareSemver("1.0.0-beta.1", "1.0.0"), -1);
+  assert.equal(compareSemver("1.0.0", "1.0.0-beta.1"), 1);
+});
+
+test("compareSemver orders prereleases of the same core version", () => {
+  assert.equal(compareSemver("1.0.0-alpha", "1.0.0-beta"), -1);
+  assert.equal(compareSemver("1.0.0-beta", "1.0.0-beta"), 0);
+});
+
+test("compareSemver returns null for non-semver input", () => {
+  assert.equal(compareSemver("latest", "1.0.0"), null);
+  assert.equal(compareSemver("1.0.0", "v1.0.0"), null);
+  assert.equal(compareSemver(undefined, "1.0.0"), null);
+});


### PR DESCRIPTION
## Summary

A depth-and-credibility pass on the existing system (no new user-facing features), driven by a fresh project review and current Agent Skills / AGENTS.md / GEO guidance.

### Engineering rigor
- New `node:test` unit suite under `test/` (25 tests, no new deps): semver comparison, CLI flag parsing, package-file matching, install-root resolution, and the **uninstall path-collection logic** (verifies a shared dir keeps unrelated skills while a dedicated extension dir is removed wholesale — the riskiest code).
- Exported `collectRemovals` from the uninstall lib so that path is directly testable.
- Added an `npm test` script and a CI step in `validate.yml`. `test/` stays out of the npm `files` allowlist, so it is not shipped to users.

### Skill-description convention
- `agentkit-seo doctor` now enforces the Agent Skills description convention: every configured skill must declare a non-empty `description` within 1024 characters that states **when** to use the skill (combats agent under-triggering). All 7 current skills already pass; this locks it in going forward.
- Documented the what+when convention in `STYLEGUIDE.md`.

### Legibility and positioning
- Added a one-source-to-many-adapters **distribution diagram** to the README repository-layout section.
- Named **AI-answer-engine readiness (GEO/AEO)** as an applied concept in `README.md` and `DESIGN.md`, mapped to the existing per-module AI-readability guidance and explicitly labeled as an evolving practice with no ranking guarantee.
- Sharpened the `llms.txt` note in `DESIGN.md` to reflect its limited 2026 adoption and unproven citation impact. Kept this in DESIGN rather than the `hub/` knowledge files, which would require a sourced citation under the repo's own source-quality rules.

### Docs
- `CHANGELOG.md` (Unreleased) and `.assets/docs/current-status.md` updated to match.

## Validation
- `npm test` → 25 pass
- `npm run validate` (doctor) → ok, including the new `skill descriptions state what and when` check
- `export --provider all` smoke → ok
- `npm pack --dry-run` → `test/` excluded from the tarball

## Notes
- Replaces the closed PR #3 work; this branch was reset to `main` first, so the diff is scoped to this pass only.
- Repo **topics / About / social-preview** are GitHub metadata (not in git) and still need a manual one-time set; recommended values were shared in the session.

https://claude.ai/code/session_01F53sv6ACdNZJ9yjZhj1MVK

---
_Generated by [Claude Code](https://claude.ai/code/session_01F53sv6ACdNZJ9yjZhj1MVK)_