### PR TITLE
feat: audit scorecards, richer skill frontmatter, Claude Code marketplace

### DIFF
--- a/.assets/docs/STYLEGUIDE.md
+++ b/.assets/docs/STYLEGUIDE.md
@@ -216,7 +216,7 @@ When generating or editing Markdown:
 - Match the correct file-class schema.
 - Set complete hidden metadata for editorial hub files.
 - Set `status: draft` for new editorial files unless told otherwise.
-- Use Agent Skills frontmatter for runtime `SKILL.md` files. The `description` must state both what the skill does and when to use it: write one or two sentences of capability, then a "Use when ..." clause listing concrete triggers. Keep it within 1024 characters and push detail into `references/`. `agentkit-seo doctor` enforces the presence, length, and "when" clause.
+- Use Agent Skills frontmatter for runtime `SKILL.md` files. The `description` must state both what the skill does and when to use it: write one or two sentences of capability, then a "Use when ..." clause listing concrete triggers. Keep it within 1024 characters and push detail into `references/`. Also set a `license` field and a `metadata` block (homepage, repository) so provenance travels with the installed skill. `agentkit-seo doctor` enforces the presence, length, "when" clause, and `license`.
 - Keep runtime references lean, procedural, and self-contained.
 - Use the current date for `last_updated`.
 - Do not add sections outside the relevant template.

--- a/.assets/docs/current-status.md
+++ b/.assets/docs/current-status.md
@@ -62,6 +62,8 @@ Working install targets:
 | `opencode` | Skills plus flat command wrappers | Commands map to shared skill names |
 | `shared` | Portable skill bundle export | Useful for manual or future provider integration |
 
+The npm CLI install path is complemented by a Claude Code plugin-marketplace channel: `.claude-plugin/marketplace.json` and `.claude-plugin/plugin.json` let users run `/plugin marketplace add agentkit-seo/agentkit-seo` and `/plugin install agentkit-seo@agentkit-seo`.
+
 Working CLI surfaces:
 
 - `agentkit-seo version`
@@ -85,7 +87,7 @@ The runtime wiki layer is installed and exported with provider bundles.
 - `llms-full.txt` concatenates the root wiki, module wiki indexes, and module knowledge files.
 - The root runtime wiki explains the graph navigation contract before agents load module details.
 - Module `SKILL.md` files use `## Wiki context` to declare when wiki files should be loaded.
-- `agentkit-seo doctor` validates wiki metadata, review dates, links, module/folder matches, skill wiki-context sections, skill description convention (what plus when, within 1024 characters), Gemini mirror coverage, and package `files` inclusion for LLM-facing files.
+- `agentkit-seo doctor` validates wiki metadata, review dates, links, module/folder matches, skill wiki-context sections, skill description convention (what plus when, within 1024 characters) and `license` field, the Claude Code marketplace and plugin manifests, Gemini mirror coverage, and package `files` inclusion for LLM-facing files.
 - `agentkit-seo-wiki-maintenance` exists in the source tree as a maintainer-only local audit workflow; it is not part of the seven installed runtime skills.
 
 ### Website and discovery status

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-marketplace.json",
+  "name": "agentkit-seo",
+  "owner": {
+    "name": "AgentKit SEO"
+  },
+  "plugins": [
+    {
+      "name": "agentkit-seo",
+      "source": "./",
+      "description": "Portable agent skills for optimizing GitHub, LinkedIn, CV/ATS, web portfolio, and X, plus agent context optimization.",
+      "version": "1.7.0",
+      "category": "productivity",
+      "keywords": [
+        "seo",
+        "career",
+        "resume",
+        "linkedin",
+        "github",
+        "portfolio",
+        "geo"
+      ],
+      "license": "MIT"
+    }
+  ]
+}

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,20 @@
+{
+  "name": "agentkit-seo",
+  "version": "1.7.0",
+  "description": "Portable agent skills for LinkedIn, GitHub, CV/ATS, portfolio SEO, X, and agent context optimization.",
+  "author": {
+    "name": "Renato Mignone and Elia Innocenti"
+  },
+  "homepage": "https://agentkit-seo.github.io/",
+  "repository": "https://github.com/agentkit-seo/agentkit-seo",
+  "license": "MIT",
+  "keywords": [
+    "agent-skills",
+    "seo",
+    "career",
+    "resume",
+    "linkedin",
+    "github",
+    "portfolio"
+  ]
+}

--- a/.skills/agent-skill/agentkit-seo-agent-context-optimization/SKILL.md
+++ b/.skills/agent-skill/agentkit-seo-agent-context-optimization/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: agentkit-seo-agent-context-optimization
 description: Build, normalize, and maintain the user's personal professional source-of-truth context so downstream platform outputs stay factual and consistent. Use when the user wants to consolidate CV data, LinkedIn exports, GitHub history, project summaries, bio facts, achievements, or positioning into a single agent-readable context file before editing platform-specific assets.
+license: MIT
+metadata:
+  homepage: https://agentkit-seo.github.io/
+  repository: https://github.com/agentkit-seo/agentkit-seo
 ---
 
 # AgentKit SEO Agent Context Optimization

--- a/.skills/agent-skill/agentkit-seo-cv-ats/SKILL.md
+++ b/.skills/agent-skill/agentkit-seo-cv-ats/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: agentkit-seo-cv-ats
 description: Optimize CV and resume content for recruiter readability and parser-safe ATS handling without making unsupported claims about exact vendor scoring. Use when the user asks about resumes, CVs, ATS formatting, keyword strategy, bullets, section order, achievement metrics, or job-targeted resume tailoring.
+license: MIT
+metadata:
+  homepage: https://agentkit-seo.github.io/
+  repository: https://github.com/agentkit-seo/agentkit-seo
 ---
 
 # AgentKit SEO CV ATS
@@ -16,6 +20,7 @@ Use only the CV and ATS guidance relevant to the requested deliverable. Keep the
 - Job-description tailoring and bullet rewrites: [references/keywords-and-bullets.md](references/keywords-and-bullets.md)
 - Parser-failure diagnosis, LaTeX/PDF post-build QA, or plain-text extraction: [references/parser-risks-and-agent-workflow.md](references/parser-risks-and-agent-workflow.md)
 - Full-document review, consistency checks, maintenance: [references/cv-audit-and-maintenance.md](references/cv-audit-and-maintenance.md)
+- Audit scorecard and prioritized fix-first ranking: [references/audit-scoring.md](references/audit-scoring.md)
 
 ## Wiki context
 
@@ -79,5 +84,6 @@ Return only requested-relevant sections. For full CV audits or broad tailoring p
 5. missing facts or evidence needed before stronger claims
 
 For audits, use concise labels such as `Verified`, `From context`, `From job description`, `Inference`, and `Inaccessible` when a claim could otherwise be ambiguous. Include a `Depth note` for full-document audits, parser debugging, or intentionally bounded reviews; omit it for narrow bullet or section rewrites unless more input is needed.
+When the user asks for a score, scorecard, or before/after comparison, also apply [references/audit-scoring.md](references/audit-scoring.md): report the overall score, band, per-category breakdown, and a fix-first ranking, labeled as an internal prioritization heuristic rather than a vendor ATS score or pass guarantee.
 
 Human playbook: [hub/cv-ats/README.md](../../../hub/cv-ats/README.md).

--- a/.skills/agent-skill/agentkit-seo-cv-ats/references/audit-scoring.md
+++ b/.skills/agent-skill/agentkit-seo-cv-ats/references/audit-scoring.md
@@ -1,0 +1,46 @@
+# CV and ATS audit score
+
+## Purpose and limits
+
+This rubric turns a CV audit into a single triage number so the user can see where to spend effort first. It is an internal prioritization heuristic, not a vendor ATS score, a parser-pass guarantee, or a hiring prediction. Applicant tracking systems differ and do not share scoring formulas; categories and weights below reflect this skill's documented parser-safety and readability guidance, not any specific vendor's algorithm.
+
+Use it only when the user asks for a score, a scorecard, or a before/after comparison. Otherwise the standard audit output is enough.
+
+Rules:
+
+- Score only categories you actually inspected. Mark uninspected categories as `Needs inspection` and exclude them from the total, then rescale the remaining weights to 100.
+- Keep every category score tied to observed evidence and never invent vendor-specific scoring.
+- Never present the number as a guaranteed ATS pass or interview outcome.
+
+## Categories and weights
+
+| Category | Weight | What it measures | Reference |
+| --- | --- | --- | --- |
+| Parser safety and formatting | 25 | machine-readable layout, fonts, columns, headers, and file form | [parser-risks-and-agent-workflow.md](parser-risks-and-agent-workflow.md) |
+| Core sections and order | 20 | expected sections present and ordered for the target role | [structure-and-formatting.md](structure-and-formatting.md) |
+| Keyword and job-description alignment | 20 | relevant, truthful keyword coverage against the target role | [keywords-and-bullets.md](keywords-and-bullets.md) |
+| Achievement bullets and evidence | 20 | outcome-focused, quantified, verifiable bullets | [keywords-and-bullets.md](keywords-and-bullets.md) |
+| Consistency and pitfalls avoided | 15 | dates, tense, naming, and common parser pitfalls | [cv-audit-and-maintenance.md](cv-audit-and-maintenance.md) |
+
+## Scoring each category
+
+Score each category from 0 to 100 percent of its weight using the linked reference checklist. Partial credit is expected: award proportional points for items present, and subtract for documented gaps. Round the weighted total to a whole number.
+
+## Bands
+
+- 85 to 100: `Excellent` - parser-safe, targeted, and evidence-backed.
+- 70 to 84: `Good` - solid with a few targeted fixes.
+- 50 to 69: `Foundation` - readable but under-targeted or thin on proof.
+- Below 50: `Critical` - parser or evidence problems likely block the CV.
+
+## Output
+
+When a score is requested, return:
+
+1. overall score and band
+2. per-category breakdown: `score / weight` plus one evidence-backed reason
+3. `Fix first`: the categories ranked by weight multiplied by the gap to full marks, so the highest-leverage fixes lead
+4. `Informational`: diagnostic observations that did not affect the score
+5. a one-line confidence note and a `Depth note` listing any categories marked `Needs inspection`, for example when only extracted text was available
+
+Keep the breakdown compact. The score exists to rank actions, so always pair it with the specific edits from the rest of this skill.

--- a/.skills/agent-skill/agentkit-seo-github/SKILL.md
+++ b/.skills/agent-skill/agentkit-seo-github/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: agentkit-seo-github
 description: Optimize GitHub profile and repository discoverability, clarity, and trust signals using documented search, metadata, and repository-structure guidance. Use when the user asks about profile README content, pinned repos, repository README structure, topics, descriptions, social preview, code search visibility, or GitHub-facing portfolio positioning.
+license: MIT
+metadata:
+  homepage: https://agentkit-seo.github.io/
+  repository: https://github.com/agentkit-seo/agentkit-seo
 ---
 
 # AgentKit SEO GitHub
@@ -16,6 +20,7 @@ Use this skill to improve GitHub discoverability, comprehension, and trust witho
 - Code search, indexing limits, Linguist, language stats: [references/search-indexing-and-linguist.md](references/search-indexing-and-linguist.md)
 - Full-profile or repository audit: [references/profile-and-repo-audit.md](references/profile-and-repo-audit.md)
 - `AGENTS.md`, Copilot instructions, AI-readable repo structure: [references/copilot-and-agent-readiness.md](references/copilot-and-agent-readiness.md)
+- Audit scorecard and prioritized fix-first ranking: [references/audit-scoring.md](references/audit-scoring.md)
 
 ## Wiki context
 
@@ -78,5 +83,6 @@ Return:
 
 For audits, make the output feel like a grounded review rather than a generic marketing report. Use concise labels such as `Verified`, `From context`, and `Inference` when a claim could otherwise be ambiguous.
 When the audit is intentionally bounded, include a one-line `Depth note` that says what was not inspected and what deeper inspection would add.
+When the user asks for a score, scorecard, or before/after comparison, also apply [references/audit-scoring.md](references/audit-scoring.md): report the overall score, band, per-category breakdown, and a fix-first ranking, labeled as an internal prioritization heuristic rather than a platform ranking.
 
 Human playbook: [hub/github/README.md](../../../hub/github/README.md).

--- a/.skills/agent-skill/agentkit-seo-github/references/audit-scoring.md
+++ b/.skills/agent-skill/agentkit-seo-github/references/audit-scoring.md
@@ -1,0 +1,49 @@
+# GitHub audit score
+
+## Purpose and limits
+
+This rubric turns a GitHub audit into a single triage number so the user can see where to spend effort first. It is an internal prioritization heuristic, not a platform metric, a ranking prediction, or a guarantee. GitHub does not publish a profile score; categories and weights below reflect this skill's documented guidance, not any internal GitHub system.
+
+Use it only when the user asks for a score, a scorecard, or a before/after comparison. Otherwise the standard audit output is enough.
+
+Rules:
+
+- Score only categories you actually inspected. Mark uninspected categories as `Needs inspection` and exclude them from the total, then rescale the remaining weights to 100.
+- Keep every category score tied to observed evidence, using the same `Verified`, `From context`, `Inference`, and `Inaccessible` labels as the rest of this skill.
+- Never present the number as a GitHub ranking or visibility guarantee.
+
+## Categories and weights
+
+| Category | Weight | What it measures | Reference |
+| --- | --- | --- | --- |
+| Profile identity and bio | 20 | bio clarity, keyword usefulness, website field, name consistency | [profile-and-repo-structure.md](profile-and-repo-structure.md) |
+| Pinned repositories and proof selection | 20 | whether pins show the strongest, most relevant work | [profile-and-repo-audit.md](profile-and-repo-audit.md) |
+| Repository README and About quality | 20 | descriptions, README openings, quickstart and evaluation paths | [section-recipes.md](section-recipes.md) |
+| Discoverability: topics, naming, language signals | 20 | topic tags, repo names, Linguist and `.gitattributes` accuracy | [search-indexing-and-linguist.md](search-indexing-and-linguist.md) |
+| Agent-readiness | 10 | `AGENTS.md` and Copilot instructions, only when the repo is agent-facing | [copilot-and-agent-readiness.md](copilot-and-agent-readiness.md) |
+| Cross-surface consistency | 10 | alignment with the context file and other public surfaces | [profile-and-repo-audit.md](profile-and-repo-audit.md) |
+
+If a category does not apply (for example, agent-readiness for a simple portfolio repository), exclude it and rescale the remaining weights to 100.
+
+## Scoring each category
+
+Score each category from 0 to 100 percent of its weight using the linked reference checklist. Partial credit is expected: award proportional points for items present, and subtract for documented gaps. Round the weighted total to a whole number.
+
+## Bands
+
+- 85 to 100: `Excellent` - strong, consistent, discoverable presence.
+- 70 to 84: `Good` - solid with a few targeted fixes.
+- 50 to 69: `Foundation` - the basics exist but key signals are missing.
+- Below 50: `Critical` - the presence does not yet communicate the user's value.
+
+## Output
+
+When a score is requested, return:
+
+1. overall score and band
+2. per-category breakdown: `score / weight` plus one evidence-backed reason
+3. `Fix first`: the categories ranked by weight multiplied by the gap to full marks, so the highest-leverage fixes lead
+4. `Informational`: diagnostic observations that did not affect the score
+5. a one-line confidence note and a `Depth note` listing any categories marked `Needs inspection`
+
+Keep the breakdown compact. The score exists to rank actions, so always pair it with the specific next changes from the rest of this skill.

--- a/.skills/agent-skill/agentkit-seo-linkedin/SKILL.md
+++ b/.skills/agent-skill/agentkit-seo-linkedin/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: agentkit-seo-linkedin
 description: Optimize LinkedIn profile structure and discoverability for headline, about, featured, experience, skills, and AI-readable positioning. Use when the user asks to improve a LinkedIn profile, headline, about section, featured section, experience entry, skills list, creator visibility, or LinkedIn search and feed discoverability.
+license: MIT
+metadata:
+  homepage: https://agentkit-seo.github.io/
+  repository: https://github.com/agentkit-seo/agentkit-seo
 ---
 
 # AgentKit SEO LinkedIn
@@ -16,6 +20,7 @@ Use only the LinkedIn module unless the user explicitly asks for cross-platform 
 - Search visibility, activity, comments, AI readability: [references/discoverability-and-activity.md](references/discoverability-and-activity.md)
 - Full-profile review, consistency checks, update workflow: [references/profile-audit-and-maintenance.md](references/profile-audit-and-maintenance.md)
 - Algorithm rationale, confidence labels, `360Brew`: [references/algorithm-confidence.md](references/algorithm-confidence.md)
+- Audit scorecard and prioritized fix-first ranking: [references/audit-scoring.md](references/audit-scoring.md)
 
 ## Wiki context
 
@@ -74,5 +79,6 @@ Return only requested-relevant sections. For audits, return:
 5. requests for the smallest missing inputs needed to finish the next pass
 
 For audits, use concise labels such as `Verified`, `From context`, `Official guidance`, `Inference`, and `Inaccessible` when a claim could otherwise be ambiguous. Include a `Depth note` only for broad audits, incomplete inputs, or intentionally deferred profile/activity review.
+When the user asks for a score, scorecard, or before/after comparison, also apply [references/audit-scoring.md](references/audit-scoring.md): report the overall score, band, per-category breakdown, and a fix-first ranking, labeled as an internal prioritization heuristic rather than a LinkedIn ranking.
 
 Human playbook: [hub/linkedin/README.md](../../../hub/linkedin/README.md).

--- a/.skills/agent-skill/agentkit-seo-linkedin/references/audit-scoring.md
+++ b/.skills/agent-skill/agentkit-seo-linkedin/references/audit-scoring.md
@@ -1,0 +1,49 @@
+# LinkedIn audit score
+
+## Purpose and limits
+
+This rubric turns a LinkedIn audit into a single triage number so the user can see where to spend effort first. It is an internal prioritization heuristic, not a LinkedIn metric, a ranking prediction, or a guarantee. LinkedIn does not publish a profile score, and its ranking systems are partly disputed; categories and weights below reflect this skill's documented guidance, not any internal LinkedIn system.
+
+Use it only when the user asks for a score, a scorecard, or a before/after comparison. Otherwise the standard audit output is enough.
+
+Rules:
+
+- Score only categories you actually inspected. Mark uninspected categories as `Needs inspection` and exclude them from the total, then rescale the remaining weights to 100.
+- Keep every category score tied to observed evidence, using the same evidence and confidence labels as the rest of this skill.
+- Never present the number as a LinkedIn ranking, reach, or visibility guarantee.
+
+## Categories and weights
+
+| Category | Weight | What it measures | Reference |
+| --- | --- | --- | --- |
+| Headline | 20 | role clarity, keywords, and positioning in the headline | [positioning-and-structure.md](positioning-and-structure.md) |
+| About section | 20 | first-person narrative, proof, and readable structure | [positioning-and-structure.md](positioning-and-structure.md) |
+| Experience, skills, and featured proof | 20 | aligned experience entries, relevant skills, and proof-of-work | [section-recipes.md](section-recipes.md) |
+| Discoverability and activity | 15 | searchable terms and documented activity signals | [discoverability-and-activity.md](discoverability-and-activity.md) |
+| Profile architecture and settings | 10 | custom URL, badges, location, and completeness | [profile-audit-and-maintenance.md](profile-audit-and-maintenance.md) |
+| AI-readable structure and consistency | 15 | clean titles, skill names, and alignment with other surfaces | [profile-audit-and-maintenance.md](profile-audit-and-maintenance.md) |
+
+If a category cannot be inspected (for example, login-gated sections), exclude it and rescale the remaining weights to 100.
+
+## Scoring each category
+
+Score each category from 0 to 100 percent of its weight using the linked reference checklist. Partial credit is expected: award proportional points for items present, and subtract for documented gaps. Round the weighted total to a whole number.
+
+## Bands
+
+- 85 to 100: `Excellent` - clear, evidence-backed, dual-audience profile.
+- 70 to 84: `Good` - solid with a few targeted fixes.
+- 50 to 69: `Foundation` - the basics exist but key sections are generic.
+- Below 50: `Critical` - the profile does not yet communicate the user's value.
+
+## Output
+
+When a score is requested, return:
+
+1. overall score and band
+2. per-category breakdown: `score / weight` plus one evidence-backed reason
+3. `Fix first`: the categories ranked by weight multiplied by the gap to full marks, so the highest-leverage fixes lead
+4. `Informational`: diagnostic observations that did not affect the score, including any ranking-dependent advice labeled by confidence
+5. a one-line confidence note and a `Depth note` listing any categories marked `Needs inspection`
+
+Keep the breakdown compact. The score exists to rank actions, so always pair it with the specific rewrites from the rest of this skill.

--- a/.skills/agent-skill/agentkit-seo-web-portfolio/SKILL.md
+++ b/.skills/agent-skill/agentkit-seo-web-portfolio/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: agentkit-seo-web-portfolio
 description: Optimize personal website and web portfolio discoverability, crawlability, metadata, structured data, content usefulness, and AI-readable signals. Use when the user asks about portfolio pages, titles, meta descriptions, canonical tags, snippets, indexability, JavaScript SEO, structured data, performance, llms.txt, or web-based personal branding.
+license: MIT
+metadata:
+  homepage: https://agentkit-seo.github.io/
+  repository: https://github.com/agentkit-seo/agentkit-seo
 ---
 
 # AgentKit SEO Web Portfolio
@@ -16,6 +20,7 @@ Use this skill to improve how a personal site is crawled, rendered, summarized, 
 - Homepage, About, project page, metadata, `llms.txt` copy: [references/section-recipes.md](references/section-recipes.md)
 - Case studies, performance, AI retrieval conventions: [references/content-performance-and-aeo.md](references/content-performance-and-aeo.md)
 - Existing-site audit or maintenance: [references/portfolio-audit-and-maintenance.md](references/portfolio-audit-and-maintenance.md)
+- Audit scorecard and prioritized fix-first ranking: [references/audit-scoring.md](references/audit-scoring.md)
 
 ## Wiki context
 
@@ -76,5 +81,6 @@ Return:
 5. context-file gaps that affect public claims
 
 For audits, use concise labels such as `Verified`, `From source`, `From context`, `Inference`, and `Inaccessible` when a claim could otherwise be ambiguous. Mark unsupported responsibilities, metrics, seniority, clients, testimonials, or outcomes as gaps rather than turning them into metadata, schema, or copy. When the audit is intentionally bounded, include a one-line `Depth note` that says what was not inspected and what deeper inspection would add.
+When the user asks for a score, scorecard, or before/after comparison, also apply [references/audit-scoring.md](references/audit-scoring.md): report the overall score, band, per-category breakdown, and a fix-first ranking, labeled as an internal prioritization heuristic rather than a ranking or indexing guarantee.
 
 Human playbook: [hub/web-portfolio/README.md](../../../hub/web-portfolio/README.md).

--- a/.skills/agent-skill/agentkit-seo-web-portfolio/references/audit-scoring.md
+++ b/.skills/agent-skill/agentkit-seo-web-portfolio/references/audit-scoring.md
@@ -1,0 +1,49 @@
+# Web portfolio audit score
+
+## Purpose and limits
+
+This rubric turns a portfolio audit into a single triage number so the user can see where to spend effort first. It is an internal prioritization heuristic, not a search-engine score, a ranking prediction, or an indexing guarantee. Search and AI systems do not publish a site score; categories and weights below reflect this skill's documented SEO, structured-data, and AI-readability guidance, not any platform's internal metric.
+
+Use it only when the user asks for a score, a scorecard, or a before/after comparison. Otherwise the standard audit output is enough.
+
+Rules:
+
+- Score only categories you actually inspected or could fetch. Mark uninspected categories as `Needs inspection` and exclude them from the total, then rescale the remaining weights to 100.
+- Keep every category score tied to observed evidence from the live site or local source.
+- Never present the number as a ranking, traffic, or AI-citation guarantee.
+
+## Categories and weights
+
+| Category | Weight | What it measures | Reference |
+| --- | --- | --- | --- |
+| Indexability and architecture | 20 | crawlability, sitemap, robots, canonical tags, and URL structure | [indexing-and-architecture.md](indexing-and-architecture.md) |
+| Metadata and snippets | 15 | titles, meta descriptions, and snippet quality | [metadata-structured-data-and-js.md](metadata-structured-data-and-js.md) |
+| Structured data | 15 | valid, accurate schema for the page types present | [metadata-structured-data-and-js.md](metadata-structured-data-and-js.md) |
+| Content and proof | 20 | clear case studies, useful copy, and proof links | [content-performance-and-aeo.md](content-performance-and-aeo.md) |
+| Performance and mobile | 15 | load behavior and mobile rendering | [content-performance-and-aeo.md](content-performance-and-aeo.md) |
+| AI readability and AEO | 15 | clean text, `llms.txt`, and answer-engine readability | [content-performance-and-aeo.md](content-performance-and-aeo.md) |
+
+If a page type is absent (for example, no article pages), exclude its checks and rescale the remaining weights to 100.
+
+## Scoring each category
+
+Score each category from 0 to 100 percent of its weight using the linked reference checklist. Partial credit is expected: award proportional points for items present, and subtract for documented gaps. Round the weighted total to a whole number.
+
+## Bands
+
+- 85 to 100: `Excellent` - crawlable, structured, fast, and AI-readable.
+- 70 to 84: `Good` - solid with a few targeted fixes.
+- 50 to 69: `Foundation` - the site works but key signals are missing.
+- Below 50: `Critical` - indexing or content problems limit discovery.
+
+## Output
+
+When a score is requested, return:
+
+1. overall score and band
+2. per-category breakdown: `score / weight` plus one evidence-backed reason
+3. `Fix first`: the categories ranked by weight multiplied by the gap to full marks, so the highest-leverage fixes lead
+4. `Informational`: diagnostic observations that did not affect the score
+5. a one-line confidence note and a `Depth note` listing any categories marked `Needs inspection`
+
+Keep the breakdown compact. The score exists to rank actions, so always pair it with the specific changes from the rest of this skill.

--- a/.skills/agent-skill/agentkit-seo-wiki-maintenance/SKILL.md
+++ b/.skills/agent-skill/agentkit-seo-wiki-maintenance/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: agentkit-seo-wiki-maintenance
 description: Maintainer-only skill for refreshing AgentKit SEO wiki knowledge from official sources. Use only from a local repository clone when a maintainer asks to refresh one module, audit all module wiki entries, or audit module source lists.
+license: MIT
+metadata:
+  homepage: https://agentkit-seo.github.io/
+  repository: https://github.com/agentkit-seo/agentkit-seo
 ---
 
 # AgentKit SEO Wiki Maintenance

--- a/.skills/agent-skill/agentkit-seo-x-twitter/SKILL.md
+++ b/.skills/agent-skill/agentkit-seo-x-twitter/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: agentkit-seo-x-twitter
 description: Optimize X and Twitter profile positioning, pinned post strategy, posting structure, and discoverability using conservative platform guidance. Use when the user asks about X or Twitter bio copy, pinned posts, content cadence, profile optimization, engagement strategy, premium tactics, or feed/search discoverability.
+license: MIT
+metadata:
+  homepage: https://agentkit-seo.github.io/
+  repository: https://github.com/agentkit-seo/agentkit-seo
 ---
 
 # AgentKit SEO X/Twitter

--- a/.skills/agent-skill/agentkit-seo/SKILL.md
+++ b/.skills/agent-skill/agentkit-seo/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: agentkit-seo
 description: Route broad or ambiguous AgentKit SEO work to the right module while keeping context scoped. Use when a request spans multiple surfaces, asks for overall digital-presence strategy, involves provider or install architecture, needs agent-context planning, or the correct platform skill is unclear.
+license: MIT
+metadata:
+  homepage: https://agentkit-seo.github.io/
+  repository: https://github.com/agentkit-seo/agentkit-seo
 ---
 
 # AgentKit SEO

--- a/.skills/export/lib/doctor.mjs
+++ b/.skills/export/lib/doctor.mjs
@@ -358,7 +358,8 @@ function readSkillFrontmatter(skillFilePath) {
 // Enforce the Agent Skills description convention: every skill states what it does
 // AND when to use it, within the 1024-character description budget. Agents tend to
 // under-trigger skills whose descriptions omit the "when", so this is a hard check.
-function validateSkillDescriptions(repoRoot, config, errors) {
+// Also require an SPDX license so it travels with the installed skill.
+function validateSkillDescriptions(repoRoot, config, errors, warnings) {
   for (const skill of config.skills ?? []) {
     const skillFile = path.join(repoRoot, skill.source, "SKILL.md");
     if (!fs.existsSync(skillFile)) {
@@ -379,12 +380,74 @@ function validateSkillDescriptions(repoRoot, config, errors) {
       errors.push(
         `${skill.source}/SKILL.md description is ${description.length} chars; keep it within 1024 and move detail into references/`
       );
+    } else if (description.length > 500) {
+      warnings.push(
+        `${skill.source}/SKILL.md description is ${description.length} chars; aim for under 500 so the trigger stays sharp`
+      );
     }
     if (!/\buse\b[\s\S]*\bwhen\b/i.test(description)) {
       errors.push(
         `${skill.source}/SKILL.md description must state when to use the skill (include a "Use when ..." clause)`
       );
     }
+    if (!/^license:\s*\S+/m.test(frontmatter)) {
+      errors.push(`${skill.source}/SKILL.md frontmatter is missing a license field`);
+    }
+  }
+}
+
+// Validate the Claude Code marketplace manifests so the /plugin distribution channel
+// stays consistent with package.json. Mirrors the gemini-extension version checks.
+function validateMarketplace(repoRoot, packageMetadata, errors) {
+  const marketplacePath = path.join(repoRoot, ".claude-plugin", "marketplace.json");
+  const pluginPath = path.join(repoRoot, ".claude-plugin", "plugin.json");
+
+  if (!fs.existsSync(marketplacePath)) {
+    errors.push("Claude Code marketplace manifest is missing: .claude-plugin/marketplace.json");
+  } else {
+    let marketplace;
+    try {
+      marketplace = readJsonFile(marketplacePath);
+    } catch {
+      errors.push(".claude-plugin/marketplace.json is not valid JSON");
+      marketplace = null;
+    }
+    if (marketplace) {
+      const entry = Array.isArray(marketplace.plugins)
+        ? marketplace.plugins.find((plugin) => plugin?.name === packageMetadata.name)
+        : null;
+      if (!entry) {
+        errors.push(
+          `.claude-plugin/marketplace.json has no plugin entry named '${packageMetadata.name}'`
+        );
+      } else if (entry.version && entry.version !== packageMetadata.version) {
+        errors.push(
+          `.claude-plugin/marketplace.json plugin version '${entry.version}' does not match package.json version '${packageMetadata.version}'`
+        );
+      }
+    }
+  }
+
+  if (!fs.existsSync(pluginPath)) {
+    errors.push("Claude Code plugin manifest is missing: .claude-plugin/plugin.json");
+    return;
+  }
+  let plugin;
+  try {
+    plugin = readJsonFile(pluginPath);
+  } catch {
+    errors.push(".claude-plugin/plugin.json is not valid JSON");
+    return;
+  }
+  if (plugin.name !== packageMetadata.name) {
+    errors.push(
+      `.claude-plugin/plugin.json name '${plugin.name ?? "missing"}' does not match package.json name '${packageMetadata.name}'`
+    );
+  }
+  if (plugin.version && plugin.version !== packageMetadata.version) {
+    errors.push(
+      `.claude-plugin/plugin.json version '${plugin.version}' does not match package.json version '${packageMetadata.version}'`
+    );
   }
 }
 
@@ -473,9 +536,10 @@ export function doctor(repoRoot, config) {
   for (const [provider, providerSpec] of Object.entries(config.providers ?? {})) {
     validateProvider(repoRoot, provider, providerSpec, packageMetadata, errors);
   }
-  validateSkillDescriptions(repoRoot, config, errors);
+  validateSkillDescriptions(repoRoot, config, errors, warnings);
   validateWikiFiles(repoRoot, config, errors, warnings);
   validateGeminiMarketplaceLayout(repoRoot, config, packageMetadata, errors);
+  validateMarketplace(repoRoot, packageMetadata, errors);
 
   for (const warning of warnings) {
     console.warn(`warning: ${warning}`);
@@ -491,6 +555,7 @@ export function doctor(repoRoot, config) {
   console.log(`ok: package ${packageMetadata.name}@${packageMetadata.version}`);
   console.log(`ok: ${config.skills.length} skill source(s)`);
   console.log("ok: skill descriptions state what and when");
+  console.log("ok: Claude Code marketplace manifests valid");
   console.log(`ok: ${Object.keys(config.providers).length} provider adapter(s)`);
   console.log("ok: context template available");
   console.log("ok: wiki files valid");

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,11 +13,14 @@ This project follows npm package versions and mirrors them with matching GitHub 
 - Added a `node:test` unit suite under `test/` covering semver comparison, CLI flag parsing, package-file matching, install-root resolution, and uninstall path collection, wired into CI through an `npm test` step in `validate.yml`.
 - Named AI-answer-engine readiness (GEO/AEO) as an applied concept in `README.md` and `DESIGN.md`, mapped to the existing per-module AI-readability guidance and labeled as an evolving practice with no ranking guarantee.
 - Added a one-source-to-many-adapters distribution diagram to the `README.md` repository layout section.
+- Added Claude Code plugin-marketplace distribution: `.claude-plugin/marketplace.json` and `.claude-plugin/plugin.json` so the skills install through `/plugin marketplace add` and `/plugin install`, included in the npm package and validated by `doctor`.
+- Added an `audit-scoring.md` reference to the GitHub, LinkedIn, CV/ATS, and web-portfolio skills: a weighted 0-100 triage scorecard with bands and a prioritized fix-first ranking, explicitly labeled as an internal prioritization heuristic rather than a platform ranking, and wired into each skill's response shape.
+- Added `license` and a `metadata` block (homepage, repository) to every runtime `SKILL.md` frontmatter so provenance travels with the installed skill.
 
 ### Changed
 
 - Extended `agentkit-seo update --provider <provider>` to read the installed provider manifest and compare that installed skill version against npm latest, so agents can suggest an explicit update check without background network behavior.
-- Extended `agentkit-seo doctor` to enforce the Agent Skills description convention: every configured skill must declare a non-empty `description` within 1024 characters that states when to use the skill. Documented the convention in `STYLEGUIDE.md`.
+- Extended `agentkit-seo doctor` to enforce the Agent Skills description convention: every configured skill must declare a non-empty `description` within 1024 characters (warning over 500) that states when to use the skill, plus a `license` field; and to validate the Claude Code marketplace and plugin manifests against `package.json`. Documented the conventions in `STYLEGUIDE.md`.
 
 ## 1.7.0 - 2026-06-01
 

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -101,6 +101,7 @@ These are influences rather than guarantees. AgentKit SEO does not claim ranking
 - The LLM Wiki framing, knowledge the model reads rather than writes, is associated with Andrej Karpathy's commentary on building knowledge for language models.
 - The context-file pattern follows the repository `AGENTS.md` and `CLAUDE.md` convention for giving agents project context before they act.
 - Progressive disclosure follows the agent-skill design idea that an agent should load instructions and reference material only when a task needs them.
+- The audit scoring pattern (weighted categories rolled into a 0-100 band with a fix-first ranking) is adapted from open generative-engine-optimization tooling such as the geo-optimizer skill, and used here strictly as an internal prioritization heuristic, not a platform metric.
 - `llms.txt` and `llms-full.txt` follow an emerging community convention for exposing an AI-readable map of a site or package. As of 2026 its adoption is still limited and its measured effect on AI citations is unproven, so this project ships it as a low-cost, honestly-labeled convention (an inferred, low-confidence signal) rather than a search-ranking lever.
 
 ---

--- a/MAINTAINING.md
+++ b/MAINTAINING.md
@@ -105,6 +105,14 @@ Do not edit these by hand:
 
 Provider adapter folders under `.skills/providers/` are thin wrappers. Put methodology changes in `hub/` and `.skills/agent-skill/`, not in provider adapter notes.
 
+## Version files to bump on release
+
+When cutting a release, set the new version in `package.json`, then keep these in sync (`agentkit-seo doctor` fails the build if any drift):
+
+- `package.json` - the source of truth.
+- `.claude-plugin/plugin.json` and the plugin entry in `.claude-plugin/marketplace.json` - bump by hand.
+- Root `gemini-extension.json` and the two provider `gemini-extension.json` files - regenerated with the correct version when you re-run the export CLI to refresh the Gemini mirror, so regenerate the mirror after the bump.
+
 ## Pull request checklist
 
 Before opening a PR that touches knowledge, skills, wiki entries, or sources:

--- a/README.md
+++ b/README.md
@@ -256,6 +256,13 @@ Supported providers:
 | `antigravity` | `~/.gemini/antigravity-cli/plugins/agentkit-seo/` | Plugin layout based on the Gemini-compatible bundle |
 | `opencode` | `~/.config/opencode/skills/` plus command wrappers | Native skill loading plus flat command wrappers |
 
+In Claude Code, the skills are also available as a plugin marketplace:
+
+```text
+/plugin marketplace add agentkit-seo/agentkit-seo
+/plugin install agentkit-seo@agentkit-seo
+```
+
 Useful package commands:
 
 ```bash

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "access": "public"
   },
   "files": [
+    ".claude-plugin",
     ".skills/agent-skill",
     ".skills/export",
     ".skills/providers",

--- a/skills/agentkit-seo-agent-context-optimization/SKILL.md
+++ b/skills/agentkit-seo-agent-context-optimization/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: agentkit-seo-agent-context-optimization
 description: Build, normalize, and maintain the user's personal professional source-of-truth context so downstream platform outputs stay factual and consistent. Use when the user wants to consolidate CV data, LinkedIn exports, GitHub history, project summaries, bio facts, achievements, or positioning into a single agent-readable context file before editing platform-specific assets.
+license: MIT
+metadata:
+  homepage: https://agentkit-seo.github.io/
+  repository: https://github.com/agentkit-seo/agentkit-seo
 ---
 
 # AgentKit SEO Agent Context Optimization

--- a/skills/agentkit-seo-cv-ats/SKILL.md
+++ b/skills/agentkit-seo-cv-ats/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: agentkit-seo-cv-ats
 description: Optimize CV and resume content for recruiter readability and parser-safe ATS handling without making unsupported claims about exact vendor scoring. Use when the user asks about resumes, CVs, ATS formatting, keyword strategy, bullets, section order, achievement metrics, or job-targeted resume tailoring.
+license: MIT
+metadata:
+  homepage: https://agentkit-seo.github.io/
+  repository: https://github.com/agentkit-seo/agentkit-seo
 ---
 
 # AgentKit SEO CV ATS
@@ -16,6 +20,7 @@ Use only the CV and ATS guidance relevant to the requested deliverable. Keep the
 - Job-description tailoring and bullet rewrites: [references/keywords-and-bullets.md](references/keywords-and-bullets.md)
 - Parser-failure diagnosis, LaTeX/PDF post-build QA, or plain-text extraction: [references/parser-risks-and-agent-workflow.md](references/parser-risks-and-agent-workflow.md)
 - Full-document review, consistency checks, maintenance: [references/cv-audit-and-maintenance.md](references/cv-audit-and-maintenance.md)
+- Audit scorecard and prioritized fix-first ranking: [references/audit-scoring.md](references/audit-scoring.md)
 
 ## Wiki context
 
@@ -79,5 +84,6 @@ Return only requested-relevant sections. For full CV audits or broad tailoring p
 5. missing facts or evidence needed before stronger claims
 
 For audits, use concise labels such as `Verified`, `From context`, `From job description`, `Inference`, and `Inaccessible` when a claim could otherwise be ambiguous. Include a `Depth note` for full-document audits, parser debugging, or intentionally bounded reviews; omit it for narrow bullet or section rewrites unless more input is needed.
+When the user asks for a score, scorecard, or before/after comparison, also apply [references/audit-scoring.md](references/audit-scoring.md): report the overall score, band, per-category breakdown, and a fix-first ranking, labeled as an internal prioritization heuristic rather than a vendor ATS score or pass guarantee.
 
 Human playbook: [hub/cv-ats/README.md](../../../hub/cv-ats/README.md).

--- a/skills/agentkit-seo-cv-ats/references/audit-scoring.md
+++ b/skills/agentkit-seo-cv-ats/references/audit-scoring.md
@@ -1,0 +1,46 @@
+# CV and ATS audit score
+
+## Purpose and limits
+
+This rubric turns a CV audit into a single triage number so the user can see where to spend effort first. It is an internal prioritization heuristic, not a vendor ATS score, a parser-pass guarantee, or a hiring prediction. Applicant tracking systems differ and do not share scoring formulas; categories and weights below reflect this skill's documented parser-safety and readability guidance, not any specific vendor's algorithm.
+
+Use it only when the user asks for a score, a scorecard, or a before/after comparison. Otherwise the standard audit output is enough.
+
+Rules:
+
+- Score only categories you actually inspected. Mark uninspected categories as `Needs inspection` and exclude them from the total, then rescale the remaining weights to 100.
+- Keep every category score tied to observed evidence and never invent vendor-specific scoring.
+- Never present the number as a guaranteed ATS pass or interview outcome.
+
+## Categories and weights
+
+| Category | Weight | What it measures | Reference |
+| --- | --- | --- | --- |
+| Parser safety and formatting | 25 | machine-readable layout, fonts, columns, headers, and file form | [parser-risks-and-agent-workflow.md](parser-risks-and-agent-workflow.md) |
+| Core sections and order | 20 | expected sections present and ordered for the target role | [structure-and-formatting.md](structure-and-formatting.md) |
+| Keyword and job-description alignment | 20 | relevant, truthful keyword coverage against the target role | [keywords-and-bullets.md](keywords-and-bullets.md) |
+| Achievement bullets and evidence | 20 | outcome-focused, quantified, verifiable bullets | [keywords-and-bullets.md](keywords-and-bullets.md) |
+| Consistency and pitfalls avoided | 15 | dates, tense, naming, and common parser pitfalls | [cv-audit-and-maintenance.md](cv-audit-and-maintenance.md) |
+
+## Scoring each category
+
+Score each category from 0 to 100 percent of its weight using the linked reference checklist. Partial credit is expected: award proportional points for items present, and subtract for documented gaps. Round the weighted total to a whole number.
+
+## Bands
+
+- 85 to 100: `Excellent` - parser-safe, targeted, and evidence-backed.
+- 70 to 84: `Good` - solid with a few targeted fixes.
+- 50 to 69: `Foundation` - readable but under-targeted or thin on proof.
+- Below 50: `Critical` - parser or evidence problems likely block the CV.
+
+## Output
+
+When a score is requested, return:
+
+1. overall score and band
+2. per-category breakdown: `score / weight` plus one evidence-backed reason
+3. `Fix first`: the categories ranked by weight multiplied by the gap to full marks, so the highest-leverage fixes lead
+4. `Informational`: diagnostic observations that did not affect the score
+5. a one-line confidence note and a `Depth note` listing any categories marked `Needs inspection`, for example when only extracted text was available
+
+Keep the breakdown compact. The score exists to rank actions, so always pair it with the specific edits from the rest of this skill.

--- a/skills/agentkit-seo-github/SKILL.md
+++ b/skills/agentkit-seo-github/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: agentkit-seo-github
 description: Optimize GitHub profile and repository discoverability, clarity, and trust signals using documented search, metadata, and repository-structure guidance. Use when the user asks about profile README content, pinned repos, repository README structure, topics, descriptions, social preview, code search visibility, or GitHub-facing portfolio positioning.
+license: MIT
+metadata:
+  homepage: https://agentkit-seo.github.io/
+  repository: https://github.com/agentkit-seo/agentkit-seo
 ---
 
 # AgentKit SEO GitHub
@@ -16,6 +20,7 @@ Use this skill to improve GitHub discoverability, comprehension, and trust witho
 - Code search, indexing limits, Linguist, language stats: [references/search-indexing-and-linguist.md](references/search-indexing-and-linguist.md)
 - Full-profile or repository audit: [references/profile-and-repo-audit.md](references/profile-and-repo-audit.md)
 - `AGENTS.md`, Copilot instructions, AI-readable repo structure: [references/copilot-and-agent-readiness.md](references/copilot-and-agent-readiness.md)
+- Audit scorecard and prioritized fix-first ranking: [references/audit-scoring.md](references/audit-scoring.md)
 
 ## Wiki context
 
@@ -78,5 +83,6 @@ Return:
 
 For audits, make the output feel like a grounded review rather than a generic marketing report. Use concise labels such as `Verified`, `From context`, and `Inference` when a claim could otherwise be ambiguous.
 When the audit is intentionally bounded, include a one-line `Depth note` that says what was not inspected and what deeper inspection would add.
+When the user asks for a score, scorecard, or before/after comparison, also apply [references/audit-scoring.md](references/audit-scoring.md): report the overall score, band, per-category breakdown, and a fix-first ranking, labeled as an internal prioritization heuristic rather than a platform ranking.
 
 Human playbook: [hub/github/README.md](../../../hub/github/README.md).

--- a/skills/agentkit-seo-github/references/audit-scoring.md
+++ b/skills/agentkit-seo-github/references/audit-scoring.md
@@ -1,0 +1,49 @@
+# GitHub audit score
+
+## Purpose and limits
+
+This rubric turns a GitHub audit into a single triage number so the user can see where to spend effort first. It is an internal prioritization heuristic, not a platform metric, a ranking prediction, or a guarantee. GitHub does not publish a profile score; categories and weights below reflect this skill's documented guidance, not any internal GitHub system.
+
+Use it only when the user asks for a score, a scorecard, or a before/after comparison. Otherwise the standard audit output is enough.
+
+Rules:
+
+- Score only categories you actually inspected. Mark uninspected categories as `Needs inspection` and exclude them from the total, then rescale the remaining weights to 100.
+- Keep every category score tied to observed evidence, using the same `Verified`, `From context`, `Inference`, and `Inaccessible` labels as the rest of this skill.
+- Never present the number as a GitHub ranking or visibility guarantee.
+
+## Categories and weights
+
+| Category | Weight | What it measures | Reference |
+| --- | --- | --- | --- |
+| Profile identity and bio | 20 | bio clarity, keyword usefulness, website field, name consistency | [profile-and-repo-structure.md](profile-and-repo-structure.md) |
+| Pinned repositories and proof selection | 20 | whether pins show the strongest, most relevant work | [profile-and-repo-audit.md](profile-and-repo-audit.md) |
+| Repository README and About quality | 20 | descriptions, README openings, quickstart and evaluation paths | [section-recipes.md](section-recipes.md) |
+| Discoverability: topics, naming, language signals | 20 | topic tags, repo names, Linguist and `.gitattributes` accuracy | [search-indexing-and-linguist.md](search-indexing-and-linguist.md) |
+| Agent-readiness | 10 | `AGENTS.md` and Copilot instructions, only when the repo is agent-facing | [copilot-and-agent-readiness.md](copilot-and-agent-readiness.md) |
+| Cross-surface consistency | 10 | alignment with the context file and other public surfaces | [profile-and-repo-audit.md](profile-and-repo-audit.md) |
+
+If a category does not apply (for example, agent-readiness for a simple portfolio repository), exclude it and rescale the remaining weights to 100.
+
+## Scoring each category
+
+Score each category from 0 to 100 percent of its weight using the linked reference checklist. Partial credit is expected: award proportional points for items present, and subtract for documented gaps. Round the weighted total to a whole number.
+
+## Bands
+
+- 85 to 100: `Excellent` - strong, consistent, discoverable presence.
+- 70 to 84: `Good` - solid with a few targeted fixes.
+- 50 to 69: `Foundation` - the basics exist but key signals are missing.
+- Below 50: `Critical` - the presence does not yet communicate the user's value.
+
+## Output
+
+When a score is requested, return:
+
+1. overall score and band
+2. per-category breakdown: `score / weight` plus one evidence-backed reason
+3. `Fix first`: the categories ranked by weight multiplied by the gap to full marks, so the highest-leverage fixes lead
+4. `Informational`: diagnostic observations that did not affect the score
+5. a one-line confidence note and a `Depth note` listing any categories marked `Needs inspection`
+
+Keep the breakdown compact. The score exists to rank actions, so always pair it with the specific next changes from the rest of this skill.

--- a/skills/agentkit-seo-linkedin/SKILL.md
+++ b/skills/agentkit-seo-linkedin/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: agentkit-seo-linkedin
 description: Optimize LinkedIn profile structure and discoverability for headline, about, featured, experience, skills, and AI-readable positioning. Use when the user asks to improve a LinkedIn profile, headline, about section, featured section, experience entry, skills list, creator visibility, or LinkedIn search and feed discoverability.
+license: MIT
+metadata:
+  homepage: https://agentkit-seo.github.io/
+  repository: https://github.com/agentkit-seo/agentkit-seo
 ---
 
 # AgentKit SEO LinkedIn
@@ -16,6 +20,7 @@ Use only the LinkedIn module unless the user explicitly asks for cross-platform 
 - Search visibility, activity, comments, AI readability: [references/discoverability-and-activity.md](references/discoverability-and-activity.md)
 - Full-profile review, consistency checks, update workflow: [references/profile-audit-and-maintenance.md](references/profile-audit-and-maintenance.md)
 - Algorithm rationale, confidence labels, `360Brew`: [references/algorithm-confidence.md](references/algorithm-confidence.md)
+- Audit scorecard and prioritized fix-first ranking: [references/audit-scoring.md](references/audit-scoring.md)
 
 ## Wiki context
 
@@ -74,5 +79,6 @@ Return only requested-relevant sections. For audits, return:
 5. requests for the smallest missing inputs needed to finish the next pass
 
 For audits, use concise labels such as `Verified`, `From context`, `Official guidance`, `Inference`, and `Inaccessible` when a claim could otherwise be ambiguous. Include a `Depth note` only for broad audits, incomplete inputs, or intentionally deferred profile/activity review.
+When the user asks for a score, scorecard, or before/after comparison, also apply [references/audit-scoring.md](references/audit-scoring.md): report the overall score, band, per-category breakdown, and a fix-first ranking, labeled as an internal prioritization heuristic rather than a LinkedIn ranking.
 
 Human playbook: [hub/linkedin/README.md](../../../hub/linkedin/README.md).

--- a/skills/agentkit-seo-linkedin/references/audit-scoring.md
+++ b/skills/agentkit-seo-linkedin/references/audit-scoring.md
@@ -1,0 +1,49 @@
+# LinkedIn audit score
+
+## Purpose and limits
+
+This rubric turns a LinkedIn audit into a single triage number so the user can see where to spend effort first. It is an internal prioritization heuristic, not a LinkedIn metric, a ranking prediction, or a guarantee. LinkedIn does not publish a profile score, and its ranking systems are partly disputed; categories and weights below reflect this skill's documented guidance, not any internal LinkedIn system.
+
+Use it only when the user asks for a score, a scorecard, or a before/after comparison. Otherwise the standard audit output is enough.
+
+Rules:
+
+- Score only categories you actually inspected. Mark uninspected categories as `Needs inspection` and exclude them from the total, then rescale the remaining weights to 100.
+- Keep every category score tied to observed evidence, using the same evidence and confidence labels as the rest of this skill.
+- Never present the number as a LinkedIn ranking, reach, or visibility guarantee.
+
+## Categories and weights
+
+| Category | Weight | What it measures | Reference |
+| --- | --- | --- | --- |
+| Headline | 20 | role clarity, keywords, and positioning in the headline | [positioning-and-structure.md](positioning-and-structure.md) |
+| About section | 20 | first-person narrative, proof, and readable structure | [positioning-and-structure.md](positioning-and-structure.md) |
+| Experience, skills, and featured proof | 20 | aligned experience entries, relevant skills, and proof-of-work | [section-recipes.md](section-recipes.md) |
+| Discoverability and activity | 15 | searchable terms and documented activity signals | [discoverability-and-activity.md](discoverability-and-activity.md) |
+| Profile architecture and settings | 10 | custom URL, badges, location, and completeness | [profile-audit-and-maintenance.md](profile-audit-and-maintenance.md) |
+| AI-readable structure and consistency | 15 | clean titles, skill names, and alignment with other surfaces | [profile-audit-and-maintenance.md](profile-audit-and-maintenance.md) |
+
+If a category cannot be inspected (for example, login-gated sections), exclude it and rescale the remaining weights to 100.
+
+## Scoring each category
+
+Score each category from 0 to 100 percent of its weight using the linked reference checklist. Partial credit is expected: award proportional points for items present, and subtract for documented gaps. Round the weighted total to a whole number.
+
+## Bands
+
+- 85 to 100: `Excellent` - clear, evidence-backed, dual-audience profile.
+- 70 to 84: `Good` - solid with a few targeted fixes.
+- 50 to 69: `Foundation` - the basics exist but key sections are generic.
+- Below 50: `Critical` - the profile does not yet communicate the user's value.
+
+## Output
+
+When a score is requested, return:
+
+1. overall score and band
+2. per-category breakdown: `score / weight` plus one evidence-backed reason
+3. `Fix first`: the categories ranked by weight multiplied by the gap to full marks, so the highest-leverage fixes lead
+4. `Informational`: diagnostic observations that did not affect the score, including any ranking-dependent advice labeled by confidence
+5. a one-line confidence note and a `Depth note` listing any categories marked `Needs inspection`
+
+Keep the breakdown compact. The score exists to rank actions, so always pair it with the specific rewrites from the rest of this skill.

--- a/skills/agentkit-seo-web-portfolio/SKILL.md
+++ b/skills/agentkit-seo-web-portfolio/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: agentkit-seo-web-portfolio
 description: Optimize personal website and web portfolio discoverability, crawlability, metadata, structured data, content usefulness, and AI-readable signals. Use when the user asks about portfolio pages, titles, meta descriptions, canonical tags, snippets, indexability, JavaScript SEO, structured data, performance, llms.txt, or web-based personal branding.
+license: MIT
+metadata:
+  homepage: https://agentkit-seo.github.io/
+  repository: https://github.com/agentkit-seo/agentkit-seo
 ---
 
 # AgentKit SEO Web Portfolio
@@ -16,6 +20,7 @@ Use this skill to improve how a personal site is crawled, rendered, summarized, 
 - Homepage, About, project page, metadata, `llms.txt` copy: [references/section-recipes.md](references/section-recipes.md)
 - Case studies, performance, AI retrieval conventions: [references/content-performance-and-aeo.md](references/content-performance-and-aeo.md)
 - Existing-site audit or maintenance: [references/portfolio-audit-and-maintenance.md](references/portfolio-audit-and-maintenance.md)
+- Audit scorecard and prioritized fix-first ranking: [references/audit-scoring.md](references/audit-scoring.md)
 
 ## Wiki context
 
@@ -76,5 +81,6 @@ Return:
 5. context-file gaps that affect public claims
 
 For audits, use concise labels such as `Verified`, `From source`, `From context`, `Inference`, and `Inaccessible` when a claim could otherwise be ambiguous. Mark unsupported responsibilities, metrics, seniority, clients, testimonials, or outcomes as gaps rather than turning them into metadata, schema, or copy. When the audit is intentionally bounded, include a one-line `Depth note` that says what was not inspected and what deeper inspection would add.
+When the user asks for a score, scorecard, or before/after comparison, also apply [references/audit-scoring.md](references/audit-scoring.md): report the overall score, band, per-category breakdown, and a fix-first ranking, labeled as an internal prioritization heuristic rather than a ranking or indexing guarantee.
 
 Human playbook: [hub/web-portfolio/README.md](../../../hub/web-portfolio/README.md).

--- a/skills/agentkit-seo-web-portfolio/references/audit-scoring.md
+++ b/skills/agentkit-seo-web-portfolio/references/audit-scoring.md
@@ -1,0 +1,49 @@
+# Web portfolio audit score
+
+## Purpose and limits
+
+This rubric turns a portfolio audit into a single triage number so the user can see where to spend effort first. It is an internal prioritization heuristic, not a search-engine score, a ranking prediction, or an indexing guarantee. Search and AI systems do not publish a site score; categories and weights below reflect this skill's documented SEO, structured-data, and AI-readability guidance, not any platform's internal metric.
+
+Use it only when the user asks for a score, a scorecard, or a before/after comparison. Otherwise the standard audit output is enough.
+
+Rules:
+
+- Score only categories you actually inspected or could fetch. Mark uninspected categories as `Needs inspection` and exclude them from the total, then rescale the remaining weights to 100.
+- Keep every category score tied to observed evidence from the live site or local source.
+- Never present the number as a ranking, traffic, or AI-citation guarantee.
+
+## Categories and weights
+
+| Category | Weight | What it measures | Reference |
+| --- | --- | --- | --- |
+| Indexability and architecture | 20 | crawlability, sitemap, robots, canonical tags, and URL structure | [indexing-and-architecture.md](indexing-and-architecture.md) |
+| Metadata and snippets | 15 | titles, meta descriptions, and snippet quality | [metadata-structured-data-and-js.md](metadata-structured-data-and-js.md) |
+| Structured data | 15 | valid, accurate schema for the page types present | [metadata-structured-data-and-js.md](metadata-structured-data-and-js.md) |
+| Content and proof | 20 | clear case studies, useful copy, and proof links | [content-performance-and-aeo.md](content-performance-and-aeo.md) |
+| Performance and mobile | 15 | load behavior and mobile rendering | [content-performance-and-aeo.md](content-performance-and-aeo.md) |
+| AI readability and AEO | 15 | clean text, `llms.txt`, and answer-engine readability | [content-performance-and-aeo.md](content-performance-and-aeo.md) |
+
+If a page type is absent (for example, no article pages), exclude its checks and rescale the remaining weights to 100.
+
+## Scoring each category
+
+Score each category from 0 to 100 percent of its weight using the linked reference checklist. Partial credit is expected: award proportional points for items present, and subtract for documented gaps. Round the weighted total to a whole number.
+
+## Bands
+
+- 85 to 100: `Excellent` - crawlable, structured, fast, and AI-readable.
+- 70 to 84: `Good` - solid with a few targeted fixes.
+- 50 to 69: `Foundation` - the site works but key signals are missing.
+- Below 50: `Critical` - indexing or content problems limit discovery.
+
+## Output
+
+When a score is requested, return:
+
+1. overall score and band
+2. per-category breakdown: `score / weight` plus one evidence-backed reason
+3. `Fix first`: the categories ranked by weight multiplied by the gap to full marks, so the highest-leverage fixes lead
+4. `Informational`: diagnostic observations that did not affect the score
+5. a one-line confidence note and a `Depth note` listing any categories marked `Needs inspection`
+
+Keep the breakdown compact. The score exists to rank actions, so always pair it with the specific changes from the rest of this skill.

--- a/skills/agentkit-seo-x-twitter/SKILL.md
+++ b/skills/agentkit-seo-x-twitter/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: agentkit-seo-x-twitter
 description: Optimize X and Twitter profile positioning, pinned post strategy, posting structure, and discoverability using conservative platform guidance. Use when the user asks about X or Twitter bio copy, pinned posts, content cadence, profile optimization, engagement strategy, premium tactics, or feed/search discoverability.
+license: MIT
+metadata:
+  homepage: https://agentkit-seo.github.io/
+  repository: https://github.com/agentkit-seo/agentkit-seo
 ---
 
 # AgentKit SEO X/Twitter

--- a/skills/agentkit-seo/SKILL.md
+++ b/skills/agentkit-seo/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: agentkit-seo
 description: Route broad or ambiguous AgentKit SEO work to the right module while keeping context scoped. Use when a request spans multiple surfaces, asks for overall digital-presence strategy, involves provider or install architecture, needs agent-context planning, or the correct platform skill is unclear.
+license: MIT
+metadata:
+  homepage: https://agentkit-seo.github.io/
+  repository: https://github.com/agentkit-seo/agentkit-seo
 ---
 
 # AgentKit SEO

--- a/test/marketplace.test.mjs
+++ b/test/marketplace.test.mjs
@@ -1,0 +1,31 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { test } from "node:test";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const pkg = JSON.parse(fs.readFileSync(path.join(repoRoot, "package.json"), "utf8"));
+
+function readJson(rel) {
+  return JSON.parse(fs.readFileSync(path.join(repoRoot, rel), "utf8"));
+}
+
+test("plugin.json name and version match package.json", () => {
+  const plugin = readJson(".claude-plugin/plugin.json");
+  assert.equal(plugin.name, pkg.name);
+  assert.equal(plugin.version, pkg.version);
+});
+
+test("marketplace.json has a matching plugin entry in sync with package.json", () => {
+  const marketplace = readJson(".claude-plugin/marketplace.json");
+  assert.ok(Array.isArray(marketplace.plugins), "plugins must be an array");
+  const entry = marketplace.plugins.find((plugin) => plugin.name === pkg.name);
+  assert.ok(entry, `expected a plugin entry named ${pkg.name}`);
+  assert.equal(entry.version, pkg.version);
+  assert.equal(entry.source, "./");
+});
+
+test(".claude-plugin is shipped in the npm files allowlist", () => {
+  assert.ok(pkg.files.includes(".claude-plugin"));
+});


### PR DESCRIPTION
## Summary

A feature-depth pass driven by a review of comparable projects (anthropics/skills, obra/superpowers, Auriti-Labs/geo-optimizer-skill, the Claude Code marketplace docs). Three improvements, two enhancing existing features and one new distribution channel.

### 1. Audit scorecards (improves the core skill output)
- New `references/audit-scoring.md` in the **github**, **linkedin**, **cv-ats**, and **web-portfolio** skills: a weighted **0–100 triage score → bands (Excellent / Good / Foundation / Critical) → prioritized fix-first ranking**, with a scoring-vs-informational split.
- Framed explicitly as an **internal prioritization heuristic, not a platform ranking or guarantee**, and integrated with the existing evidence/confidence labels — staying within the project's source/claim discipline.
- Wired into each skill's Reference selection and Response shape; flows into all six provider exports.

### 2. Richer SKILL.md frontmatter + tighter lint
- Added `license: MIT` and a `metadata` block (homepage, repository) to all eight runtime `SKILL.md` frontmatters so provenance travels with the installed skill.
- `agentkit-seo doctor` now also requires a `license` field and warns when a description exceeds the 500-char sharpness budget (hard cap stays 1024). Documented in `STYLEGUIDE.md`.

### 3. Claude Code plugin-marketplace distribution (new channel)
- Added `.claude-plugin/marketplace.json` and `.claude-plugin/plugin.json` (`source: "./"`, reusing the existing root `skills/` and `commands/`), shipped `.claude-plugin` in the npm `files` allowlist, and validated both manifests against `package.json` in `doctor`.
- Added a marketplace unit test and the `/plugin marketplace add` + `/plugin install` path to the README.

### Docs
- Regenerated the root Gemini mirror.
- Updated `CHANGELOG.md`, `.assets/docs/current-status.md`, `MAINTAINING.md` (new "Version files to bump on release"), and `DESIGN.md` (scoring attribution).

## Validation
- `npm test` → 28 pass (adds marketplace manifest test)
- `npm run validate` (doctor) → ok, including the new `Claude Code marketplace manifests valid` and `license` checks
- `export --provider all` → ok; the scorecard reference reaches all six providers
- `install` + `uninstall --dry-run` smoke → ok
- `npm pack --dry-run` → `.claude-plugin` included, `test/` excluded

## Notes
- Pure additions; no behavioral change to existing CLI commands.
- The `Unreleased` changelog is now substantial (this work plus the earlier test/design/GEO layers) — a natural **1.8.0**, whose version-file bump checklist is documented in `MAINTAINING.md`.

https://claude.ai/code/session_01F53sv6ACdNZJ9yjZhj1MVK

---
_Generated by [Claude Code](https://claude.ai/code/session_01F53sv6ACdNZJ9yjZhj1MVK)_