### PR TITLE
Release 1.8.0: persona + self-review, context goals, LLM Wiki fix, refreshed docs

### DIFF
--- a/.skills/agent-skill/agentkit-seo-agent-context-optimization/SKILL.md
+++ b/.skills/agent-skill/agentkit-seo-agent-context-optimization/SKILL.md
@@ -11,7 +11,7 @@ metadata:
 
 ## Overview
 
-Use this skill before any cross-platform optimization pass that depends on a stable factual record. The goal is to turn scattered inputs into one reliable, agent-readable context file.
+Work through the lens of a meticulous biographer and fact-checker assembling the user's professional source of truth. Use this skill before any cross-platform optimization pass that depends on a stable factual record. The goal is to turn scattered inputs into one reliable, agent-readable context file.
 
 ## Workflow
 
@@ -55,6 +55,8 @@ Default to `Default pass` for broad context-file work. Offer `Deep reconciliatio
 - If no path is supplied, ask where the file should live before writing: in the current workspace, at an explicit user path, or at a portable default such as `~/.agentkit-seo/<name-surname>-seo-context.md`.
 - Do not assume the agent can write outside the current workspace. If writing requires permission, ask before writing.
 - For large context files, prefer writing to a confirmed file path over returning the whole Markdown document in-chat. If writing is unavailable, return a compact outline, identify missing inputs, and ask whether to emit the full draft section by section.
+- When building or repairing a context file, also capture the user's direction, not just their history: ideal role or dream job, current focus and what they want to work on next, professional and personal interests, and target locations for applications (specific cities or countries, remote or hybrid preference, willingness to relocate, or no restriction). Ask for any of these that are missing, and record "no restriction" or "open" explicitly rather than leaving a guess.
+- Treat these goals as the user's stated intent, not verified facts. Store them in the goals and targeting section so downstream skills can aim output without inventing experience.
 - If the user gives scattered material, normalize it into the canonical context structure before platform rewriting.
 - Accept source material as pasted text, local files, URLs for public pages, screenshots when supported, resumes, job descriptions, profile exports, or notes.
 - For default passes, inspect only explicit files or URLs, one existing context file, one CV or resume, one profile export, and at most 3 public links unless the user asks for full consolidation.
@@ -72,6 +74,18 @@ Default to `Default pass` for broad context-file work. Offer `Deep reconciliatio
 - Keep the context file as the factual source of truth; platform skills add formatting and channel constraints, not facts.
 - When drafting from scratch, produce the canonical section order first and populate only verified material.
 - When updating an existing file, prefer targeted entry-level edits over rewriting the whole document.
+- Keep the user's goals, interests, and targeting separate from verified facts. Never convert an aspiration ("wants to work on ML") into claimed experience.
+
+## Self-review
+
+Before returning, check the draft and fix or flag any failure:
+
+- Every fact traces to supplied source material or the existing file; nothing was invented or upgraded beyond its evidence.
+- Goals, interests, and target locations are recorded as stated intent, kept distinct from verified facts.
+- Conflicts across inputs are surfaced, not silently resolved.
+- The output matches the requested scope and storage mode.
+
+If a check fails and cannot be resolved from the available inputs, say so explicitly instead of smoothing it over.
 
 ## Handoff
 

--- a/.skills/agent-skill/agentkit-seo-cv-ats/SKILL.md
+++ b/.skills/agent-skill/agentkit-seo-cv-ats/SKILL.md
@@ -11,7 +11,7 @@ metadata:
 
 ## Overview
 
-Use only the CV and ATS guidance relevant to the requested deliverable. Keep the advice conservative, parser-safe, and grounded in documented, durable constraints.
+Work through the lens of a recruiter screening resumes against ATS parsers and the target role's hiring bar. Use only the CV and ATS guidance relevant to the requested deliverable. Keep the advice conservative, parser-safe, and grounded in documented, durable constraints.
 
 ## Reference selection
 
@@ -72,6 +72,17 @@ Default to `Default audit` for broad CV or resume reviews. Offer `Deep audit` as
 - Optimize for reliable parsing first, recruiter readability second, and visual polish third.
 - Preserve factual alignment with the user's context file, LinkedIn, and public portfolio.
 - For rewrites, improve section clarity and evidence density before changing the user's positioning strategy.
+
+## Self-review
+
+Before returning, check the draft and fix or flag any failure:
+
+- No fabricated tools, metrics, employers, dates, or credentials; every keyword and bullet traces to supplied material, the context file, or the job description.
+- No guaranteed-ATS-pass or exact-vendor-scoring claims; parser advice stays within documented, durable constraints.
+- Output matches the requested scope, the target role and job description, and the user's stated goals; nothing drifted into unrequested work.
+- Parser safety leads, then recruiter readability, then polish, with the highest-impact fixes first.
+
+If a check fails and cannot be fixed from available inputs, say so rather than papering over it.
 
 ## Response shape
 

--- a/.skills/agent-skill/agentkit-seo-github/SKILL.md
+++ b/.skills/agent-skill/agentkit-seo-github/SKILL.md
@@ -11,7 +11,7 @@ metadata:
 
 ## Overview
 
-Use this skill to improve GitHub discoverability, comprehension, and trust without claiming undocumented ranking guarantees.
+Work through the lens of a pragmatic engineering hiring manager and open-source maintainer skimming the profile. Use this skill to improve GitHub discoverability, comprehension, and trust without claiming undocumented ranking guarantees.
 
 ## Reference selection
 
@@ -70,6 +70,17 @@ Default to `Default audit` for broad profile requests. Offer `Deep audit` as an 
 - Keep profile metadata, pinned repositories, README copy, and repository structure aligned around the same public positioning.
 - For rewrites, improve clarity, proof, and discoverability before inventing a more aggressive branding angle.
 - Recommend `AGENTS.md` or Copilot instruction files only when the repository is agent-facing, complex enough to need operational guidance, or the user explicitly asks for agent-readiness work.
+
+## Self-review
+
+Before returning, check the draft and fix or flag any failure:
+
+- No fabricated metrics, percentiles, ranking mechanics, or pinned/archived/licensed status; every claim traces to inspected GitHub material, the context file, or is labeled inference.
+- Evidence labels are correct and not upgraded beyond their source.
+- Output matches the requested scope, the target role, and the user's stated goals and target locations; nothing drifted into unrequested work.
+- The highest-impact fixes lead, and copy stays factual to the user's real work.
+
+If a check fails and cannot be fixed from available inputs, say so rather than papering over it.
 
 ## Response shape
 

--- a/.skills/agent-skill/agentkit-seo-linkedin/SKILL.md
+++ b/.skills/agent-skill/agentkit-seo-linkedin/SKILL.md
@@ -11,7 +11,7 @@ metadata:
 
 ## Overview
 
-Use only the LinkedIn module unless the user explicitly asks for cross-platform alignment. Keep claims conservative, search-oriented, and easy to justify.
+Work through the lens of a technical recruiter and the user's career editor. Use only the LinkedIn module unless the user explicitly asks for cross-platform alignment. Keep claims conservative, search-oriented, and easy to justify.
 
 ## Reference selection
 
@@ -67,6 +67,17 @@ Default to `Default audit` for broad LinkedIn profile requests. Offer `Deep audi
 - Prefer standard job titles and explicit skills over novelty phrasing.
 - Keep structured profile fields, prose sections, proof links, and recent activity aligned around the same positioning.
 - For section rewrites, preserve factual claims and improve only structure, clarity, and discoverability unless the user asks for strategic repositioning.
+
+## Self-review
+
+Before returning, check the draft and fix or flag any failure:
+
+- No invented credentials, metrics, or employers; every claim traces to LinkedIn material, the context file, or is labeled inference, with disputed ranking behavior kept disputed.
+- Evidence and confidence labels are correct and not upgraded beyond their source.
+- Output matches the requested scope, the target role, and the user's stated goals and target locations; nothing drifted into unrequested work.
+- Rewrites preserve the user's real facts and lead with the highest-impact changes.
+
+If a check fails and cannot be fixed from available inputs, say so rather than papering over it.
 
 ## Response shape
 

--- a/.skills/agent-skill/agentkit-seo-web-portfolio/SKILL.md
+++ b/.skills/agent-skill/agentkit-seo-web-portfolio/SKILL.md
@@ -11,7 +11,7 @@ metadata:
 
 ## Overview
 
-Use this skill to improve how a personal site is crawled, rendered, summarized, and trusted by search engines and AI systems.
+Work through the lens of a technical SEO specialist and a hiring manager skimming the site. Use this skill to improve how a personal site is crawled, rendered, summarized, and trusted by search engines and AI systems.
 
 ## Reference selection
 
@@ -69,6 +69,17 @@ Default to `Default audit` for broad portfolio audits. Offer `Deep audit` as an 
 - When facts are missing, ask for the canonical URL, page inventory, or source content before inventing portfolio copy or structured data.
 - When editing portfolio code, preserve existing styling and application logic unless the user explicitly asks for a redesign. Prefer metadata, structured data, semantic HTML, crawlability, and content changes before layout changes.
 - For direct code edits, run the available build, lint, test, or preview command when the project provides one, and report any verification that could not run.
+
+## Self-review
+
+Before returning, check the draft and fix or flag any failure:
+
+- No invented projects, testimonials, metrics, employers, or credentials; structured data and copy reflect only verified or supplied facts.
+- Rankings, rich results, and indexing are framed as eligibility, not guarantees; emerging conventions are not presented as standards.
+- Output matches the requested scope and the user's stated goals; metadata, structured data, and visible copy stay consistent for each page.
+- Any code edits preserve existing styling and logic, and verification that could not run is reported.
+
+If a check fails and cannot be fixed from available inputs, say so rather than papering over it.
 
 ## Response shape
 

--- a/.skills/agent-skill/agentkit-seo-x-twitter/SKILL.md
+++ b/.skills/agent-skill/agentkit-seo-x-twitter/SKILL.md
@@ -11,7 +11,7 @@ metadata:
 
 ## Overview
 
-Use the X/Twitter hub to improve profile clarity and posting structure while avoiding overclaims about undocumented live ranking systems.
+Work through the lens of an editor growing a credible technical audience for the user. Use the X/Twitter hub to improve profile clarity and posting structure while avoiding overclaims about undocumented live ranking systems.
 
 ## Reference selection
 
@@ -65,6 +65,17 @@ Default to `Default audit` for broad account or profile requests. Offer `Deep au
 - Distinguish official product features, current recommender documentation, historical/open-source inference, and empirical tactics.
 - Keep profile positioning, pinned assets, posting topics, and linked external proof aligned around one clear niche.
 - When profile proof, audience, or posting history is missing, ask for it before inventing claims or forcing a content strategy.
+
+## Self-review
+
+Before returning, check the draft and fix or flag any failure:
+
+- No promised ranking outcomes and no invented analytics, Premium status, or proof; every claim traces to public material, the context file, or is labeled by confidence.
+- Premium, paid-tier, and ranking advice is verified against current official docs or labeled historical or inferred.
+- Output matches the requested scope, the user's real niche and capacity, and their stated goals; nothing drifted into unrequested cadence or strategy.
+- Profile, pinned assets, topics, and linked proof stay aligned around one clear niche.
+
+If a check fails and cannot be fixed from available inputs, say so rather than papering over it.
 
 ## Response shape
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,13 @@ This project follows npm package versions and mirrors them with matching GitHub 
 - Added Claude Code plugin-marketplace distribution: `.claude-plugin/marketplace.json` and `.claude-plugin/plugin.json` so the skills install through `/plugin marketplace add` and `/plugin install`, included in the npm package and validated by `doctor`.
 - Added an `audit-scoring.md` reference to the GitHub, LinkedIn, CV/ATS, and web-portfolio skills: a weighted 0-100 triage scorecard with bands and a prioritized fix-first ranking, explicitly labeled as an internal prioritization heuristic rather than a platform ranking, and wired into each skill's response shape.
 - Added `license` and a `metadata` block (homepage, repository) to every runtime `SKILL.md` frontmatter so provenance travels with the installed skill.
+- Added a `Goals and targeting` section to the agent-context-file spec, template, and intake workflow, capturing the user's ideal role, current focus, what they want to work on next, target locations (or `No restriction`), interests, and constraints as stated intent kept separate from verified facts, so downstream skills can aim output without inventing experience.
+- Added a professional-persona lens to each skill's overview (for example, hiring manager and open-source maintainer for GitHub, technical recruiter for LinkedIn) to focus the agent's perspective.
+- Added a `Self-review` step to every skill: before returning, the agent checks the draft for fabricated facts, correct evidence labels, scope and goal alignment, and impact ordering, and flags any failure it cannot fix.
 
 ### Changed
+
+- Corrected the LLM Wiki attribution in `README.md` and `DESIGN.md`: the wiki is compiled and kept current by a maintainer agent and read by runtime agents instead of re-derived per query, and documented how the design deliberately adapts Karpathy's personal-second-brain concept to a shipped, versioned knowledge pack.
 
 - Extended `agentkit-seo update --provider <provider>` to read the installed provider manifest and compare that installed skill version against npm latest, so agents can suggest an explicit update check without background network behavior.
 - Extended `agentkit-seo doctor` to enforce the Agent Skills description convention: every configured skill must declare a non-empty `description` within 1024 characters (warning over 500) that states when to use the skill, plus a `license` field; and to validate the Claude Code marketplace and plugin manifests against `package.json`. Documented the conventions in `STYLEGUIDE.md`.

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -20,7 +20,7 @@ The following table maps each concept to its origin and to where it lives in the
 | Concept | One-line idea | Where it lives |
 | --- | --- | --- |
 | Career context file | A private `AGENTS.md` for a person: verified facts an agent reads before writing | [`agentkit-seo-agent-context-optimization`](./.skills/agent-skill/agentkit-seo-agent-context-optimization/SKILL.md) |
-| LLM Wiki | A knowledge base the model reads, not one it writes | [`*/wiki/`](./.skills/agent-skill/agentkit-seo/wiki/agentkit-seo.md), [`llms-full.txt`](./llms-full.txt) |
+| LLM Wiki | A knowledge base a maintainer agent compiles from sources and keeps current, read by runtime agents rather than re-derived per query | [`*/wiki/`](./.skills/agent-skill/agentkit-seo/wiki/agentkit-seo.md), [`llms-full.txt`](./llms-full.txt) |
 | Progressive disclosure | Load one module, then only the references and wiki a task needs | `## Wiki context` and token-discipline sections in each `SKILL.md` |
 | Markdown knowledge graph | Cross-referenced `.md` files with one entrypoint and explicit edges | [`references/`](./.skills/agent-skill/agentkit-seo/references/) link graph, [`llms.txt`](./llms.txt) |
 | Evidence and confidence labels | Mark each claim as verified, inferred, or needing evidence | `Boundaries` sections and `wiki/` confidence metadata |
@@ -33,7 +33,9 @@ Developers already accept that a repository should carry a context file so an ag
 
 ### LLM Wiki: knowledge the model reads, not writes
 
-The wiki layer follows the LLM Wiki framing associated with Andrej Karpathy: a curated knowledge base that the model consults, rather than one it generates on the fly. Without it, an agent guesses platform constraints, ATS parser behavior, field limits, ranking signals, from training data, and produces confident but wrong advice. Each module ships `wiki/` entries with canonical definitions, platform constraints, known failure modes, and review dates, bundled for tools as [`llms-full.txt`](./llms-full.txt).
+The wiki layer follows the LLM Wiki framing associated with Andrej Karpathy: a maintainer agent compiles knowledge from official sources and keeps it current, and runtime agents read that compiled knowledge rather than re-deriving it from training data on every query. Without it, an agent guesses platform constraints, ATS parser behavior, field limits, and ranking signals, and produces confident but wrong advice. Each module ships `wiki/` entries with canonical definitions, platform constraints, known failure modes, and review dates, bundled for tools as [`llms-full.txt`](./llms-full.txt).
+
+This adapts Karpathy's design to a shipped package. His LLM Wiki is a personal, ever-growing second brain an agent accumulates from a user's own ingested sources; AgentKit SEO instead ships a curated, versioned knowledge pack about external platform behavior, refreshed by the maintainer-only `agentkit-seo-wiki-maintenance` skill (ingest and lint) rather than mutated during end-user sessions. It keeps the faithful core, compile-once and keep-current instead of per-query retrieval, while deliberately dropping per-user accumulation that does not fit a distributed package.
 
 ### Progressive disclosure and token discipline
 

--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ AgentKit SEO is a small system that applies current agentic-AI ideas, not just a
 | Concept | One-line idea | Where it lives |
 | --- | --- | --- |
 | Career context file | A private `AGENTS.md` for a person: verified facts an agent reads before writing | [agent-context-optimization](./.skills/agent-skill/agentkit-seo-agent-context-optimization/SKILL.md) |
-| LLM Wiki | A knowledge base the model reads, not one it writes | [`wiki/`](./.skills/agent-skill/agentkit-seo/wiki/agentkit-seo.md), [llms-full.txt](./llms-full.txt) |
+| LLM Wiki | A knowledge base a maintainer agent compiles from sources and keeps current, which runtime agents read instead of re-deriving facts per query | [`wiki/`](./.skills/agent-skill/agentkit-seo/wiki/agentkit-seo.md), [llms-full.txt](./llms-full.txt) |
 | Progressive disclosure | Load one module, then only the references a task needs | `## Wiki context` sections in each `SKILL.md` |
 | Markdown knowledge graph | Cross-referenced `.md` files with one entrypoint and explicit edges | [references](./.skills/agent-skill/agentkit-seo/references/), [llms.txt](./llms.txt) |
 | Evidence and confidence labels | Mark each claim as verified, inferred, or needing evidence | `Boundaries` sections and `wiki/` metadata |
@@ -198,7 +198,7 @@ flowchart TD
 
 ## LLM Wiki
 
-Without a knowledge layer, agents guess at platform constraints from training data: ATS parser behavior, LinkedIn field limits, GitHub Linguist rules, and other details that change or depend on context. That guessing produces confident but wrong advice. AgentKit SEO's wiki layer follows Andrej Karpathy's LLM Wiki concept: a knowledge base the LLM reads, not one it writes. A maintainer-only wiki refresh skill exists in the source tree for local source audits; the installed user bundle still ships only the runtime skills.
+Without a knowledge layer, agents guess at platform constraints from training data: ATS parser behavior, LinkedIn field limits, GitHub Linguist rules, and other details that change or depend on context. That guessing produces confident but wrong advice. AgentKit SEO's wiki layer follows Andrej Karpathy's LLM Wiki concept: a maintainer agent compiles the knowledge from sources and keeps it current, and runtime agents read it instead of re-deriving platform facts on every query. A maintainer-only wiki refresh skill exists in the source tree for local source audits; the installed user bundle still ships only the runtime skills.
 
 - Every skill ships with per-module Markdown entries for canonical definitions, platform constraints with confidence labels, known failure modes, evidence rules, and audit output rules.
 - Wiki entries load conditionally, so agents pull deeper context only when the current task needs it.

--- a/hub/agent-context-optimization/context-file-spec.md
+++ b/hub/agent-context-optimization/context-file-spec.md
@@ -23,22 +23,23 @@ The file can live wherever the user wants. Prefer an explicit user-chosen path. 
 
 ## 2. File structure
 
-The context file contains ten sections in a fixed order. The table below defines the requirement status of each section.
+The context file contains eleven sections in a fixed order. The table below defines the requirement status of each section.
 
 | # | Section | Status |
 |---|---|---|
 | 1 | Title | Required |
 | 2 | QUICK REFERENCE block | Required |
-| 3 | Scope declaration | Required |
-| 4 | Education | Required |
-| 5 | Professional experience | Conditional |
-| 6 | Research and publications | Conditional |
-| 7 | Skills index | Required |
-| 8 | Certifications and achievements | Conditional |
-| 9 | Languages | Required |
-| 10 | Extracurricular and leadership | Optional |
+| 3 | Goals and targeting | Recommended |
+| 4 | Scope declaration | Required |
+| 5 | Education | Required |
+| 6 | Professional experience | Conditional |
+| 7 | Research and publications | Conditional |
+| 8 | Skills index | Required |
+| 9 | Certifications and achievements | Conditional |
+| 10 | Languages | Required |
+| 11 | Extracurricular and leadership | Optional |
 
-**Required:** present in every valid context file. **Conditional:** present if the described content exists. **Optional:** may be omitted.
+**Required:** present in every valid context file. **Recommended:** include unless the user declines; it sharpens downstream targeting. **Conditional:** present if the described content exists. **Optional:** may be omitted.
 
 ### 2.1 Title
 
@@ -61,6 +62,11 @@ name: Firstname Lastname
 current_location: City, Country
 target_roles: [Role A, Role B]
 open_to_relocation: true/false
+target_locations: [City, Country, Remote-Region]   # or [No restriction]
+work_mode: remote/hybrid/onsite
+ideal_role: The role the person ultimately wants
+current_focus: What the person is working on and improving now
+interests: [interest1, interest2, interest3]
 
 education:
   - "[DEGREE] Degree Name | Institution | Grade | Month Year"
@@ -96,7 +102,26 @@ portfolio: https://yoursite.com
 
 The `gpa_summary` field lists all graded courses on a single comma-separated line. This lets an agent retrieve the full academic record without leaving the block.
 
-### 2.3 Scope declaration
+### 2.3 Goals and targeting
+
+Place the **Goals and targeting** section immediately after the QUICK REFERENCE block. It records where the person wants to go, so downstream skills can aim role, tone, location, and keyword choices.
+
+**Rule:** This section holds stated intent and preferences, not verified facts. Keep it separate from the verified record and never convert an aspiration into claimed experience. Do not list it inside the `<!-- VERIFIED FACTS -->` comment.
+
+```markdown
+## Goals and targeting
+
+**Ideal role:** The role the person ultimately wants.
+**Current focus:** What the person is working on and improving now.
+**Want to work on next:** Problems, domains, or responsibilities they are aiming for.
+**Target locations:** Cities, countries, remote or hybrid preference, relocation stance, or No restriction.
+**Interests:** Professional and personal interests that shape direction.
+**Constraints:** Visa, availability, role types to avoid, or No restriction.
+```
+
+**Rule:** Write `No restriction` where the person has no constraint rather than omitting the line, so an agent does not guess.
+
+### 2.4 Scope declaration
 
 The **scope declaration** is a single paragraph written in third person. It states what the file is, what it is not, and what it is for. Write it so an agent can read it as instructions rather than self-description.
 
@@ -114,7 +139,7 @@ cert score=NNN, cert id=XXXXXXX, competition result=Nth place, score=XXXXXXX -->
 
 The HTML comment is invisible in rendered Markdown but visible to any agent reading raw text.
 
-### 2.4 Education
+### 2.5 Education
 
 Write each degree as an H2 heading using the `[DEGREE]` tag.
 
@@ -169,7 +194,7 @@ Write the thesis as an H3 entry under its parent degree, using the `[THESIS]` ta
 **TL;DR:** One sentence — contribution and outcome.
 ```
 
-### 2.5 Professional experience
+### 2.6 Professional experience
 
 Write each role as an H3 entry using the `[ROLE]` tag.
 
@@ -186,7 +211,7 @@ If the role is the industry context for a thesis, add a cross-reference on the l
 *This role is the industry context for the [THESIS] documented under [degree section].*
 ```
 
-### 2.6 Research and publications
+### 2.7 Research and publications
 
 Include this section only if the person has formal research outputs: published papers, preprints, DOI-linked reports, or papers under review.
 
@@ -202,7 +227,7 @@ Write each paper as an H3 entry using the `[PAPER]` or `[PREPRINT]` tag.
 
 For work not yet published, use `[PREPRINT]` and add the status after the year: `| Under review` or `| In preparation`.
 
-### 2.7 Skills index
+### 2.8 Skills index
 
 **Rule:** Write the Skills index as a flat categorical enumeration. Do not use prose or bullet lists.
 
@@ -222,7 +247,7 @@ Write each category as a bold label followed by a comma-separated list on the sa
 
 Add or remove categories to match the person's field. **Rule:** Every skill listed must appear in at least one other section of the file. Do not add skills without supporting evidence in the body.
 
-### 2.8 Certifications and achievements
+### 2.9 Certifications and achievements
 
 Write each entry as an H3 using the appropriate tag. The three entry types and their formats are shown below.
 
@@ -237,7 +262,7 @@ Score: overall score and per-component breakdown if applicable.
 One sentence describing what was recognized and in what context.
 ```
 
-### 2.9 Languages
+### 2.10 Languages
 
 **Rule:** Write the Languages section as a table. Do not use prose.
 
@@ -251,7 +276,7 @@ The table below shows the required columns and an example row for each case.
 
 Use CEFR levels as the standard. Include standardized test scores and IDs in the Certificate column.
 
-### 2.10 Extracurricular and leadership
+### 2.11 Extracurricular and leadership
 
 Write each entry as an H3 using the `[ORG]` tag.
 
@@ -396,6 +421,7 @@ Before considering a context file complete, verify all of the following items.
 
 - [ ] The file opens with an H1 title in the specified format.
 - [ ] The QUICK REFERENCE YAML block is complete and appears before the scope declaration.
+- [ ] The Goals and targeting section is present (or intentionally declined), holds stated intent only, and is kept out of the `<!-- VERIFIED FACTS -->` comment.
 - [ ] The scope declaration includes the `<!-- VERIFIED FACTS: ... -->` comment.
 - [ ] Every verified fact in the file appears inside the `<!-- VERIFIED FACTS: ... -->` comment.
 - [ ] Every H3 and deeper heading representing a professional artifact has a semantic tag.

--- a/hub/agent-context-optimization/templates/context-file-template.md
+++ b/hub/agent-context-optimization/templates/context-file-template.md
@@ -72,6 +72,16 @@ current_location: Amsterdam, Netherlands
 target_roles: [Site Reliability Engineer, Platform Engineer, Backend Engineer]
 # Whether you are willing to relocate for the right opportunity
 open_to_relocation: true
+# Cities or countries you target for applications; use [no restriction] if open
+target_locations: [Amsterdam, Berlin, Remote-EU]
+# Preferred work mode: remote, hybrid, or onsite
+work_mode: hybrid
+# The role you ultimately want, even if a step beyond your current target
+ideal_role: Staff Site Reliability Engineer
+# What you are focused on now and want to work on next
+current_focus: Kubernetes operator development and SLO-driven reliability
+# Professional and personal interests that shape your direction
+interests: [open-source infrastructure, distributed systems, mentoring, climbing]
 
 education:
   # Format: "[DEGREE] Degree Name | Institution | Grade | Month Year"
@@ -116,6 +126,11 @@ name:
 current_location:
 target_roles: []
 open_to_relocation:
+target_locations: []
+work_mode:
+ideal_role:
+current_focus:
+interests: []
 
 education:
   - ""
@@ -139,6 +154,32 @@ languages:
 
 github:
 linkedin:
+```
+
+### Goals and targeting
+
+This section records where you want to go, not what you have already done. Unlike the rest of the file, it holds stated intent and preferences rather than verified facts, so downstream skills can aim output (role, tone, location, keywords) without inventing experience. Keep it honest but forward-looking, and write `No restriction` wherever you have no constraint.
+
+Good example:
+
+```markdown
+**Ideal role:** Staff Site Reliability Engineer at an infrastructure-focused product company.
+**Current focus:** Kubernetes operator development and SLO-driven reliability; want to move from service ownership into platform-wide reliability.
+**Want to work on next:** developer-platform tooling, incident-reduction systems, and mentoring junior engineers.
+**Target locations:** Amsterdam or Berlin on a hybrid basis; open to remote within the EU. No relocation outside the EU for now.
+**Interests:** open-source infrastructure, distributed systems, technical writing, climbing.
+**Constraints:** needs visa sponsorship outside the EU; not pursuing pure management tracks.
+```
+
+Replace the block below with your own goals and targeting. Keep each line to stated intent, and use `No restriction` where you have no constraint:
+
+```markdown
+**Ideal role:** [The role you ultimately want.]
+**Current focus:** [What you are working on and improving now.]
+**Want to work on next:** [Problems, domains, or responsibilities you are aiming for.]
+**Target locations:** [Cities, countries, remote or hybrid preference, relocation stance, or No restriction.]
+**Interests:** [Professional and personal interests that shape your direction.]
+**Constraints:** [Visa, availability, role types to avoid, or No restriction.]
 ```
 
 ### Scope declaration

--- a/skills/agentkit-seo-agent-context-optimization/SKILL.md
+++ b/skills/agentkit-seo-agent-context-optimization/SKILL.md
@@ -11,7 +11,7 @@ metadata:
 
 ## Overview
 
-Use this skill before any cross-platform optimization pass that depends on a stable factual record. The goal is to turn scattered inputs into one reliable, agent-readable context file.
+Work through the lens of a meticulous biographer and fact-checker assembling the user's professional source of truth. Use this skill before any cross-platform optimization pass that depends on a stable factual record. The goal is to turn scattered inputs into one reliable, agent-readable context file.
 
 ## Workflow
 
@@ -55,6 +55,8 @@ Default to `Default pass` for broad context-file work. Offer `Deep reconciliatio
 - If no path is supplied, ask where the file should live before writing: in the current workspace, at an explicit user path, or at a portable default such as `~/.agentkit-seo/<name-surname>-seo-context.md`.
 - Do not assume the agent can write outside the current workspace. If writing requires permission, ask before writing.
 - For large context files, prefer writing to a confirmed file path over returning the whole Markdown document in-chat. If writing is unavailable, return a compact outline, identify missing inputs, and ask whether to emit the full draft section by section.
+- When building or repairing a context file, also capture the user's direction, not just their history: ideal role or dream job, current focus and what they want to work on next, professional and personal interests, and target locations for applications (specific cities or countries, remote or hybrid preference, willingness to relocate, or no restriction). Ask for any of these that are missing, and record "no restriction" or "open" explicitly rather than leaving a guess.
+- Treat these goals as the user's stated intent, not verified facts. Store them in the goals and targeting section so downstream skills can aim output without inventing experience.
 - If the user gives scattered material, normalize it into the canonical context structure before platform rewriting.
 - Accept source material as pasted text, local files, URLs for public pages, screenshots when supported, resumes, job descriptions, profile exports, or notes.
 - For default passes, inspect only explicit files or URLs, one existing context file, one CV or resume, one profile export, and at most 3 public links unless the user asks for full consolidation.
@@ -72,6 +74,18 @@ Default to `Default pass` for broad context-file work. Offer `Deep reconciliatio
 - Keep the context file as the factual source of truth; platform skills add formatting and channel constraints, not facts.
 - When drafting from scratch, produce the canonical section order first and populate only verified material.
 - When updating an existing file, prefer targeted entry-level edits over rewriting the whole document.
+- Keep the user's goals, interests, and targeting separate from verified facts. Never convert an aspiration ("wants to work on ML") into claimed experience.
+
+## Self-review
+
+Before returning, check the draft and fix or flag any failure:
+
+- Every fact traces to supplied source material or the existing file; nothing was invented or upgraded beyond its evidence.
+- Goals, interests, and target locations are recorded as stated intent, kept distinct from verified facts.
+- Conflicts across inputs are surfaced, not silently resolved.
+- The output matches the requested scope and storage mode.
+
+If a check fails and cannot be resolved from the available inputs, say so explicitly instead of smoothing it over.
 
 ## Handoff
 

--- a/skills/agentkit-seo-cv-ats/SKILL.md
+++ b/skills/agentkit-seo-cv-ats/SKILL.md
@@ -11,7 +11,7 @@ metadata:
 
 ## Overview
 
-Use only the CV and ATS guidance relevant to the requested deliverable. Keep the advice conservative, parser-safe, and grounded in documented, durable constraints.
+Work through the lens of a recruiter screening resumes against ATS parsers and the target role's hiring bar. Use only the CV and ATS guidance relevant to the requested deliverable. Keep the advice conservative, parser-safe, and grounded in documented, durable constraints.
 
 ## Reference selection
 
@@ -72,6 +72,17 @@ Default to `Default audit` for broad CV or resume reviews. Offer `Deep audit` as
 - Optimize for reliable parsing first, recruiter readability second, and visual polish third.
 - Preserve factual alignment with the user's context file, LinkedIn, and public portfolio.
 - For rewrites, improve section clarity and evidence density before changing the user's positioning strategy.
+
+## Self-review
+
+Before returning, check the draft and fix or flag any failure:
+
+- No fabricated tools, metrics, employers, dates, or credentials; every keyword and bullet traces to supplied material, the context file, or the job description.
+- No guaranteed-ATS-pass or exact-vendor-scoring claims; parser advice stays within documented, durable constraints.
+- Output matches the requested scope, the target role and job description, and the user's stated goals; nothing drifted into unrequested work.
+- Parser safety leads, then recruiter readability, then polish, with the highest-impact fixes first.
+
+If a check fails and cannot be fixed from available inputs, say so rather than papering over it.
 
 ## Response shape
 

--- a/skills/agentkit-seo-github/SKILL.md
+++ b/skills/agentkit-seo-github/SKILL.md
@@ -11,7 +11,7 @@ metadata:
 
 ## Overview
 
-Use this skill to improve GitHub discoverability, comprehension, and trust without claiming undocumented ranking guarantees.
+Work through the lens of a pragmatic engineering hiring manager and open-source maintainer skimming the profile. Use this skill to improve GitHub discoverability, comprehension, and trust without claiming undocumented ranking guarantees.
 
 ## Reference selection
 
@@ -70,6 +70,17 @@ Default to `Default audit` for broad profile requests. Offer `Deep audit` as an 
 - Keep profile metadata, pinned repositories, README copy, and repository structure aligned around the same public positioning.
 - For rewrites, improve clarity, proof, and discoverability before inventing a more aggressive branding angle.
 - Recommend `AGENTS.md` or Copilot instruction files only when the repository is agent-facing, complex enough to need operational guidance, or the user explicitly asks for agent-readiness work.
+
+## Self-review
+
+Before returning, check the draft and fix or flag any failure:
+
+- No fabricated metrics, percentiles, ranking mechanics, or pinned/archived/licensed status; every claim traces to inspected GitHub material, the context file, or is labeled inference.
+- Evidence labels are correct and not upgraded beyond their source.
+- Output matches the requested scope, the target role, and the user's stated goals and target locations; nothing drifted into unrequested work.
+- The highest-impact fixes lead, and copy stays factual to the user's real work.
+
+If a check fails and cannot be fixed from available inputs, say so rather than papering over it.
 
 ## Response shape
 

--- a/skills/agentkit-seo-linkedin/SKILL.md
+++ b/skills/agentkit-seo-linkedin/SKILL.md
@@ -11,7 +11,7 @@ metadata:
 
 ## Overview
 
-Use only the LinkedIn module unless the user explicitly asks for cross-platform alignment. Keep claims conservative, search-oriented, and easy to justify.
+Work through the lens of a technical recruiter and the user's career editor. Use only the LinkedIn module unless the user explicitly asks for cross-platform alignment. Keep claims conservative, search-oriented, and easy to justify.
 
 ## Reference selection
 
@@ -67,6 +67,17 @@ Default to `Default audit` for broad LinkedIn profile requests. Offer `Deep audi
 - Prefer standard job titles and explicit skills over novelty phrasing.
 - Keep structured profile fields, prose sections, proof links, and recent activity aligned around the same positioning.
 - For section rewrites, preserve factual claims and improve only structure, clarity, and discoverability unless the user asks for strategic repositioning.
+
+## Self-review
+
+Before returning, check the draft and fix or flag any failure:
+
+- No invented credentials, metrics, or employers; every claim traces to LinkedIn material, the context file, or is labeled inference, with disputed ranking behavior kept disputed.
+- Evidence and confidence labels are correct and not upgraded beyond their source.
+- Output matches the requested scope, the target role, and the user's stated goals and target locations; nothing drifted into unrequested work.
+- Rewrites preserve the user's real facts and lead with the highest-impact changes.
+
+If a check fails and cannot be fixed from available inputs, say so rather than papering over it.
 
 ## Response shape
 

--- a/skills/agentkit-seo-web-portfolio/SKILL.md
+++ b/skills/agentkit-seo-web-portfolio/SKILL.md
@@ -11,7 +11,7 @@ metadata:
 
 ## Overview
 
-Use this skill to improve how a personal site is crawled, rendered, summarized, and trusted by search engines and AI systems.
+Work through the lens of a technical SEO specialist and a hiring manager skimming the site. Use this skill to improve how a personal site is crawled, rendered, summarized, and trusted by search engines and AI systems.
 
 ## Reference selection
 
@@ -69,6 +69,17 @@ Default to `Default audit` for broad portfolio audits. Offer `Deep audit` as an 
 - When facts are missing, ask for the canonical URL, page inventory, or source content before inventing portfolio copy or structured data.
 - When editing portfolio code, preserve existing styling and application logic unless the user explicitly asks for a redesign. Prefer metadata, structured data, semantic HTML, crawlability, and content changes before layout changes.
 - For direct code edits, run the available build, lint, test, or preview command when the project provides one, and report any verification that could not run.
+
+## Self-review
+
+Before returning, check the draft and fix or flag any failure:
+
+- No invented projects, testimonials, metrics, employers, or credentials; structured data and copy reflect only verified or supplied facts.
+- Rankings, rich results, and indexing are framed as eligibility, not guarantees; emerging conventions are not presented as standards.
+- Output matches the requested scope and the user's stated goals; metadata, structured data, and visible copy stay consistent for each page.
+- Any code edits preserve existing styling and logic, and verification that could not run is reported.
+
+If a check fails and cannot be fixed from available inputs, say so rather than papering over it.
 
 ## Response shape
 

--- a/skills/agentkit-seo-x-twitter/SKILL.md
+++ b/skills/agentkit-seo-x-twitter/SKILL.md
@@ -11,7 +11,7 @@ metadata:
 
 ## Overview
 
-Use the X/Twitter hub to improve profile clarity and posting structure while avoiding overclaims about undocumented live ranking systems.
+Work through the lens of an editor growing a credible technical audience for the user. Use the X/Twitter hub to improve profile clarity and posting structure while avoiding overclaims about undocumented live ranking systems.
 
 ## Reference selection
 
@@ -65,6 +65,17 @@ Default to `Default audit` for broad account or profile requests. Offer `Deep au
 - Distinguish official product features, current recommender documentation, historical/open-source inference, and empirical tactics.
 - Keep profile positioning, pinned assets, posting topics, and linked external proof aligned around one clear niche.
 - When profile proof, audience, or posting history is missing, ask for it before inventing claims or forcing a content strategy.
+
+## Self-review
+
+Before returning, check the draft and fix or flag any failure:
+
+- No promised ranking outcomes and no invented analytics, Premium status, or proof; every claim traces to public material, the context file, or is labeled by confidence.
+- Premium, paid-tier, and ranking advice is verified against current official docs or labeled historical or inferred.
+- Output matches the requested scope, the user's real niche and capacity, and their stated goals; nothing drifted into unrequested cadence or strategy.
+- Profile, pinned assets, topics, and linked proof stay aligned around one clear niche.
+
+If a check fails and cannot be fixed from available inputs, say so rather than papering over it.
 
 ## Response shape
 


### PR DESCRIPTION
## Summary

Cuts the **1.8.0** release. Bundles the product-quality pass (persona, self-review, context-file goals, LLM Wiki attribution fix) with a full documentation refresh and the version bump.

1.8.0 is a **minor** bump per semver: all changes are additive (new agent behavior, new docs, new distribution channel), with no breaking changes to the CLI or install contract.

### Agent behavior (better output)
- **Role-grounded persona** on every user-facing skill (GitHub: hiring manager + maintainer; LinkedIn: technical recruiter; CV/ATS: ATS screener; portfolio: SEO specialist; X: audience editor; context: biographer + fact-checker).
- **Self-review step** per skill: before returning, the agent checks for fabricated facts, evidence-label accuracy, scope/goal alignment, and impact ordering, and flags anything it cannot fix.

### Career context file: goals and targeting
Intake, spec, and template now capture the user's direction, ideal role, current focus, what they want to work on next, target locations (or `No restriction`), interests, and constraints, as **stated intent** kept separate from verified facts.

### LLM Wiki accuracy
- Corrected the Karpathy attribution in `README.md` / `DESIGN.md` (maintainer agent compiles and keeps current; runtime agents read instead of re-deriving), with a note on adapting his concept to a shipped, versioned pack.

### Documentation refresh
- `README.md` design-principles table: new rows for persona + self-review and the audit scorecard; context-file row notes goals and targeting.
- `.assets/docs/current-status.md`: bumped to 1.8.0 / 2026-06-07; records personas, self-review, audit-scoring references, license/metadata frontmatter, and the context-file goals section.
- `.assets/docs/project.md`: goals and targeting, persona + self-review, and the six version-bearing files in the release model.
- `.assets/docs/architecture-map.md`: new layer rows for the Claude Code plugin marketplace and the CLI unit tests; release checklist aligned with the six version files and `npm test`.
- `.assets/docs/getting-started.md` + `end-to-end-workflows.md`: version string and context demo updated.

### Version bump (six files, doctor-enforced)
`package.json`, `.claude-plugin/plugin.json`, the `marketplace.json` plugin entry, and the root + two provider `gemini-extension.json` -> `1.8.0`. CHANGELOG `Unreleased` moved into `1.8.0 - 2026-06-07`.

## Verification
- `npm test` -> 28/28 pass
- `npm run validate` (doctor) -> green, including "provider metadata versions match package.json"
- Root Gemini mirror byte-identical to a fresh export; export manifest reports 1.8.0
- `npm pack --dry-run` -> `agentkit-seo-1.8.0.tgz`, 246 files

## Shipping
The npm publish workflow fires on a pushed `v1.8.0` tag. That tag should point at `main` **after** this PR merges, so the published version and `main` stay aligned. I have not created the tag (npm publish is public and irreversible); see the PR thread for the go-ahead.

https://claude.ai/code/session_01F53sv6ACdNZJ9yjZhj1MVK