### PR TITLE
release: 1.8.0

### DIFF
--- a/.assets/docs/architecture-map.md
+++ b/.assets/docs/architecture-map.md
@@ -44,6 +44,8 @@ Do not load every skill module by default. Route to one module unless the task i
 | Release automation | `.github/workflows/` | Validation and npm publication workflows | CI, release checks, package publication, or tag behavior changes |
 | Public release notes | `CHANGELOG.md` | User-facing release history | Any package-visible behavior changes |
 | Package metadata | `package.json` | npm package metadata, bin command, scripts, and version | CLI, dependencies, package files, scripts, or version changes |
+| Claude Code plugin marketplace | `.claude-plugin/marketplace.json`, `.claude-plugin/plugin.json` | `/plugin` install channel and plugin manifest, validated by `doctor` against `package.json` | Plugin metadata, marketplace listing, or version changes |
+| CLI unit tests | `test/` | Deterministic `node:test` suite for the export CLI library, run by `npm test` in CI | CLI library behavior in semver, arg parsing, package-file matching, install-root, or uninstall paths changes |
 
 ## 4. Source-of-truth rules
 
@@ -105,11 +107,11 @@ Provider wrappers must route to the shared skill names:
 
 Before pushing a release tag:
 
-1. Update `package.json`.
-2. Update any provider manifest with an explicit package version.
+1. Set the new version in `package.json`, then keep the six version-bearing files in sync (`doctor` fails on drift): `package.json`, `.claude-plugin/plugin.json`, the plugin entry in `.claude-plugin/marketplace.json`, the root `gemini-extension.json`, and the two provider `gemini-extension.json` files. See [MAINTAINING.md](../../MAINTAINING.md#version-files-to-bump-on-release).
+2. Regenerate the Gemini mirror through the export CLI so the Gemini manifests pick up the new version.
 3. Move public changes from `CHANGELOG.md` `Unreleased` into the new version section.
 4. Update `.assets/docs/current-status.md` with the current package version and release list.
-5. Run `npm run validate`.
+5. Run `npm test` and `npm run validate`.
 6. Run CLI smoke tests for changed commands.
 7. Run provider export or install smoke tests for changed providers.
 8. Run `npm pack --dry-run`.

--- a/.assets/docs/current-status.md
+++ b/.assets/docs/current-status.md
@@ -2,14 +2,14 @@
 
 This file is the maintainer snapshot for what is live, what is packaged, and what remains open. Keep public positioning in `README.md`; keep operational status here.
 
-## As of 2026-06-01
+## As of 2026-06-07
 
 ### Public surfaces
 
 - Source repo: `https://github.com/agentkit-seo/agentkit-seo`
 - Website and human-readable hub: `https://agentkit-seo.github.io/`
 - npm package: `https://www.npmjs.com/package/agentkit-seo`
-- Current package version: `agentkit-seo@1.7.0`
+- Current package version: `agentkit-seo@1.8.0`
 
 Published release line:
 
@@ -17,6 +17,7 @@ Published release line:
 - `v1.5.0` through `v1.5.3`
 - `v1.6.0` through `v1.6.1`
 - `v1.7.0`
+- `v1.8.0`
 
 ### Current architecture
 
@@ -45,9 +46,12 @@ The installable user bundle ships seven portable runtime skill bundles:
 
 Each runtime module carries:
 
-- `SKILL.md`
-- local `references/`
+- `SKILL.md`, with a role-grounded professional persona in its overview and a `## Self-review` step that checks the draft for fabricated facts, evidence-label accuracy, scope and goal alignment, and impact ordering before returning
+- local `references/`, including an `audit-scoring.md` weighted 0-100 triage scorecard on the GitHub, LinkedIn, CV/ATS, and web-portfolio modules (an internal prioritization heuristic, not a platform ranking)
 - local `wiki/` entries where durable constraints, confidence labels, failure modes, and audit rules belong
+- `license` and a `metadata` block (homepage, repository) in frontmatter so provenance travels with the installed skill
+
+The `agentkit-seo-agent-context-optimization` module additionally captures the user's direction, not only their history: a `Goals and targeting` section in the context-file spec, template, and intake records ideal role, current focus, what they want to work on next, target locations (or `No restriction`), interests, and constraints as stated intent kept separate from verified facts.
 
 ### Install and distribution status
 

--- a/.assets/docs/end-to-end-workflows.md
+++ b/.assets/docs/end-to-end-workflows.md
@@ -70,6 +70,8 @@ Create my agent-context-file from these inputs:
 
 Write the result to ~/.agentkit-seo/<name>-context.md if file editing is available.
 Separate verified facts, supplied context, inferences, and missing evidence.
+Also capture my goals and targeting: ideal role, current focus, what I want to
+work on next, target locations (or no restriction), interests, and constraints.
 Ask before turning uncertain claims into public copy.
 ```
 
@@ -79,6 +81,7 @@ Expected output:
 - context-file draft or saved file path
 - source ledger for every major claim
 - conflicts found across CV, LinkedIn, GitHub, and portfolio material
+- goals and targeting captured as stated intent, kept separate from verified facts
 - missing evidence list
 - reusable positioning summary
 - next recommended platform skill

--- a/.assets/docs/getting-started.md
+++ b/.assets/docs/getting-started.md
@@ -51,7 +51,7 @@ npx agentkit-seo version
 Expected output:
 
 ```text
-agentkit-seo 1.7.0
+agentkit-seo 1.8.0
 Portable agent skills for LinkedIn, GitHub, CV/ATS, portfolio SEO, X, and agent context optimization.
 ```
 

--- a/.assets/docs/project.md
+++ b/.assets/docs/project.md
@@ -6,7 +6,7 @@ AgentKit SEO is a two-surface system: a public human-readable website and an ins
 
 AgentKit SEO lets a user install a focused skill bundle into their preferred coding agent, point it at career material, and receive grounded optimization work for LinkedIn, GitHub, CVs, portfolios, X/Twitter, and reusable professional context files.
 
-The core workflow is context first. A private agent context file acts like a `CLAUDE.md` or `AGENTS.md` for a person's career: verified facts, constraints, target roles, links, achievements, and positioning live in one reusable Markdown source of truth outside this repository.
+The core workflow is context first. A private agent context file acts like a `CLAUDE.md` or `AGENTS.md` for a person's career: verified facts, constraints, target roles, links, achievements, and positioning live in one reusable Markdown source of truth outside this repository. The file also records the user's direction in a `Goals and targeting` section, ideal role, current focus, what they want to work on next, target locations (or no restriction), interests, and constraints, kept as stated intent separate from verified facts so downstream skills can aim output without inventing experience.
 
 ## 2. Public surfaces
 
@@ -90,6 +90,8 @@ The package ships these shared skills:
 
 This modular shape solves the context-window problem: a LinkedIn task should load the LinkedIn skill, not the whole system.
 
+Each user-facing module opens its `SKILL.md` from a role-grounded professional persona (for example a hiring manager and maintainer for GitHub, a technical recruiter for LinkedIn) and runs a `## Self-review` step before returning, checking for fabricated facts, evidence-label accuracy, scope and goal alignment, and impact ordering. The GitHub, LinkedIn, CV/ATS, and web-portfolio modules also ship an `audit-scoring.md` weighted 0-100 triage scorecard used strictly as an internal prioritization heuristic, not a platform ranking.
+
 The source tree also contains `agentkit-seo-wiki-maintenance` as a maintainer-only workflow for local source audits and wiki refreshes. It is not part of the installed user runtime bundle.
 
 ## 6. Install model
@@ -113,9 +115,9 @@ The npm package is the canonical registry artifact. GitHub releases mirror npm v
 
 Before release:
 
-1. Update package and provider manifest versions.
+1. Set the new version in `package.json`, then keep the six version-bearing files in sync: `package.json`, `.claude-plugin/plugin.json`, the plugin entry in `.claude-plugin/marketplace.json`, the root `gemini-extension.json`, and the two provider `gemini-extension.json` files (the Gemini manifests are refreshed by regenerating the mirror through the export CLI). `agentkit-seo doctor` fails on any drift.
 2. Update `CHANGELOG.md` and `.assets/docs/current-status.md`.
-3. Run `npm run validate`.
+3. Run `npm test` and `npm run validate`.
 4. Run provider export or install smoke tests.
 5. Run `npm pack --dry-run`.
 6. Push an annotated `vX.Y.Z` tag.

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "agentkit-seo",
       "source": "./",
       "description": "Portable agent skills for optimizing GitHub, LinkedIn, CV/ATS, web portfolio, and X, plus agent context optimization.",
-      "version": "1.7.0",
+      "version": "1.8.0",
       "category": "productivity",
       "keywords": [
         "seo",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agentkit-seo",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "description": "Portable agent skills for LinkedIn, GitHub, CV/ATS, portfolio SEO, X, and agent context optimization.",
   "author": {
     "name": "Renato Mignone and Elia Innocenti"

--- a/.skills/providers/antigravity/extension/gemini-extension.json
+++ b/.skills/providers/antigravity/extension/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "agentkit-seo",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "description": "Portable personal-branding and discoverability skills for LinkedIn, GitHub, CV/ATS, web portfolios, X, and agent-readable context files.",
   "contextFileName": "GEMINI.md"
 }

--- a/.skills/providers/gemini-cli/extension/gemini-extension.json
+++ b/.skills/providers/gemini-cli/extension/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "agentkit-seo",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "description": "Portable personal-branding and discoverability skills for LinkedIn, GitHub, CV/ATS, web portfolios, X, and agent-readable context files.",
   "contextFileName": "GEMINI.md"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ This project follows npm package versions and mirrors them with matching GitHub 
 
 ## Unreleased
 
+## 1.8.0 - 2026-06-07
+
 ### Added
 
 - Added `DESIGN.md`, a human and recruiter-facing overview that maps each applied agentic-AI concept (career context file, LLM Wiki, progressive disclosure, Markdown knowledge graph, evidence labeling, one-source-many-adapters) to its origin and to where it lives in the source tree, with a knowledge-graph diagram and a release-by-release record of how the design evolved.

--- a/README.md
+++ b/README.md
@@ -160,13 +160,15 @@ AgentKit SEO is a small system that applies current agentic-AI ideas, not just a
 
 | Concept | One-line idea | Where it lives |
 | --- | --- | --- |
-| Career context file | A private `AGENTS.md` for a person: verified facts an agent reads before writing | [agent-context-optimization](./.skills/agent-skill/agentkit-seo-agent-context-optimization/SKILL.md) |
+| Career context file | A private `AGENTS.md` for a person: verified facts plus stated goals and targeting an agent reads before writing | [agent-context-optimization](./.skills/agent-skill/agentkit-seo-agent-context-optimization/SKILL.md) |
 | LLM Wiki | A knowledge base a maintainer agent compiles from sources and keeps current, which runtime agents read instead of re-deriving facts per query | [`wiki/`](./.skills/agent-skill/agentkit-seo/wiki/agentkit-seo.md), [llms-full.txt](./llms-full.txt) |
 | Progressive disclosure | Load one module, then only the references a task needs | `## Wiki context` sections in each `SKILL.md` |
 | Markdown knowledge graph | Cross-referenced `.md` files with one entrypoint and explicit edges | [references](./.skills/agent-skill/agentkit-seo/references/), [llms.txt](./llms.txt) |
 | Evidence and confidence labels | Mark each claim as verified, inferred, or needing evidence | `Boundaries` sections and `wiki/` metadata |
 | One source, many adapters | Keep one portable source, generate per-provider layouts | [`.skills/agent-skill/`](./.skills/agent-skill/), [`.skills/providers/`](./.skills/providers/) |
 | AI-answer-engine readiness (GEO/AEO) | Structure each surface so AI search and assistants can quote a person accurately | [GitHub Copilot indexing](./hub/github/copilot-and-agents.md), [LinkedIn AI structure](./hub/linkedin/ai-agent-optimization.md), [portfolio AEO](./hub/web-portfolio/llms-and-aeo.md) |
+| Role-grounded persona and self-review | Each skill reasons as the relevant professional (hiring manager, recruiter, ATS screener) and checks its own draft for fabrication, evidence labels, and scope before returning | each module `SKILL.md` overview and its `## Self-review` step |
+| Audit scorecard | Weighted 0-100 triage with bands and a fix-first order, used as an internal prioritization heuristic, not a platform ranking | [audit-scoring.md](./.skills/agent-skill/agentkit-seo-github/references/audit-scoring.md) |
 
 Hiring discovery increasingly runs through AI answer engines, so the same properties these modules enforce, consistent facts across surfaces and verifiable proof, are what those systems can quote accurately. The project treats generative and answer engine optimization as an evolving practice with no guaranteed ranking outcome, not a promise.
 

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "agentkit-seo",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "description": "Portable personal-branding and discoverability skills for LinkedIn, GitHub, CV/ATS, web portfolios, X, and agent-readable context files.",
   "contextFileName": "GEMINI.md"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agentkit-seo",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "description": "Portable agent skills for LinkedIn, GitHub, CV/ATS, portfolio SEO, X, and agent context optimization.",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary

Cuts **1.8.0**. PR #6 was merged before this release commit landed, so `main` is still at 1.7.0 while the feature work (persona, self-review, context goals, LLM Wiki fix) is already merged. This PR carries the remaining release commit: the version bump, the documentation refresh, and the CHANGELOG cut.

1.8.0 is a **minor** bump per semver, all changes since 1.7.0 are additive.

### What this commit contains
- **Version bump to 1.8.0** across the six doctor-enforced files: `package.json`, `.claude-plugin/plugin.json`, the `marketplace.json` plugin entry, and the root + two provider `gemini-extension.json`.
- **CHANGELOG** `Unreleased` moved into `1.8.0 - 2026-06-07`.
- **Docs refresh:** README design-principles table (persona + self-review and audit-scorecard rows; context-file goals); `current-status.md` (1.8.0 / 2026-06-07, persona/self-review/scorecard/license/goals); `project.md` (goals, persona, six version files); `architecture-map.md` (marketplace + tests layers, release checklist); `getting-started.md` + `end-to-end-workflows.md`.

## Verification
- `npm test` -> 28/28 pass
- `npm run validate` (doctor) -> green, including "provider metadata versions match package.json"
- Root Gemini mirror byte-identical to a fresh export; export manifest reports 1.8.0
- `npm pack --dry-run` -> `agentkit-seo-1.8.0.tgz`, 246 files

## Shipping
After this merges, a `v1.8.0` tag pushed on `main` triggers the npm publish workflow.

https://claude.ai/code/session_01F53sv6ACdNZJ9yjZhj1MVK

---
_Generated by [Claude Code](https://claude.ai/code/session_01F53sv6ACdNZJ9yjZhj1MVK)_